### PR TITLE
Less strict dimensions encoder

### DIFF
--- a/src/main/java/com/reandroid/apk/xmlencoder/XMLValuesEncoderDimen.java
+++ b/src/main/java/com/reandroid/apk/xmlencoder/XMLValuesEncoderDimen.java
@@ -25,7 +25,7 @@ import com.reandroid.arsc.value.Entry;
     @Override
     void encodeStringValue(Entry entry, String value){
         ValueDecoder.EncodeResult encodeResult =
-                ValueDecoder.encodeDimensionOrFloat(value);
+                ValueDecoder.encodeDimension(value);
         if(encodeResult==null){
             encodeResult=ValueDecoder.encodeHexOrInt(value);
         }

--- a/src/main/java/com/reandroid/apk/xmlencoder/XMLValuesEncoderInteger.java
+++ b/src/main/java/com/reandroid/apk/xmlencoder/XMLValuesEncoderInteger.java
@@ -31,7 +31,7 @@ class XMLValuesEncoderInteger extends XMLValuesEncoder{
         }else if(ValueDecoder.isHex(value)){
             entry.setValueAsRaw(ValueType.INT_HEX, ValueDecoder.parseHex(value));
         }else {
-            ValueDecoder.EncodeResult encodeResult=ValueDecoder.encodeDimensionOrFloat(value);
+            ValueDecoder.EncodeResult encodeResult=ValueDecoder.encodeFloat(value);
             if(encodeResult!=null){
                 entry.setValueAsRaw(encodeResult.valueType, encodeResult.value);
             }else {


### PR DESCRIPTION
Values such as `24dip` and `24.0dp` are now interpreted as dimensions, just like with aapt-based tools.