### PR TITLE
feat: make XMLValuesEncoder register new entries

### DIFF
--- a/src/main/java/com/reandroid/apk/xmlencoder/XMLValuesEncoder.java
+++ b/src/main/java/com/reandroid/apk/xmlencoder/XMLValuesEncoder.java
@@ -46,10 +46,7 @@ class XMLValuesEncoder {
     }
     private void encode(TypeBlock typeBlock, XMLElement element){
         String name = element.getAttributeValue("name");
-        int resourceId = getMaterials()
-                .resolveLocalResourceId(typeBlock.getTypeName(), name);
-        Entry entry = typeBlock
-                .getOrCreateEntry((short) (0xffff & resourceId));
+        Entry entry = typeBlock.getOrCreateEntry(name);
 
         encodeValue(entry, element);
 


### PR DESCRIPTION
You inquired about this commit over on the ReVanced repository. These changes make `XMLValuesEncoder` automatically register new resource so you do not have to manually add them in `res/values/public.xml`, which is useful if you are trying to modify apps.