### PR TITLE
fix: determination of the base module

### DIFF
--- a/src/main/java/com/reandroid/apk/ApkModule.java
+++ b/src/main/java/com/reandroid/apk/ApkModule.java
@@ -459,7 +459,7 @@ public class ApkModule implements ApkFile, Closeable {
         AndroidManifestBlock manifest;
         try {
             manifest= getAndroidManifest();
-            return manifest.getMainActivity()!=null;
+            return !(manifest.isSplit() || manifest.getMainActivity()==null);
         } catch (Exception ignored) {
             return false;
         }


### PR DESCRIPTION
Some split modules may have a « MainActivity ».
Which can mislead the merger.

