### PR TITLE
Fixes handling of applications without packages in resources

### DIFF
--- a/src/main/java/com/reandroid/apk/ApkModule.java
+++ b/src/main/java/com/reandroid/apk/ApkModule.java
@@ -841,7 +841,7 @@ public class ApkModule implements ApkFile, Closeable {
         }
         packageBlock = tableBlock.pickOne(manifestBlock.guessCurrentPackageId());
         if(packageBlock == null) {
-            packageBlock = tableBlock.pickOne();
+            packageBlock = tableBlock.pickOrEmptyPackage();
         }
         if(packageBlock != null) {
             manifestBlock.setPackageBlock(packageBlock);

--- a/src/main/java/com/reandroid/apk/ApkModuleXmlEncoder.java
+++ b/src/main/java/com/reandroid/apk/ApkModuleXmlEncoder.java
@@ -82,7 +82,7 @@ public class ApkModuleXmlEncoder extends ApkModuleEncoder{
         if(packageId != null){
             packageBlock = tableBlock.pickOne(packageId);
         }else {
-            packageBlock = tableBlock.pickOne();
+            packageBlock = tableBlock.pickOrEmptyPackage();
         }
         if(packageBlock != null){
             tableBlock.setCurrentPackage(packageBlock);


### PR DESCRIPTION
After one of the latest changes the handling of applications that don't contain packages in the .arsc file broke down:
```
ERROR:
java.io.IOException: Can not decode without package
	at com.reandroid.arsc.chunk.xml.ResXmlDocument.serialize(ResXmlDocument.java:509)
	at com.reandroid.apk.ApkModuleXmlDecoder.serializeXml(ApkModuleXmlDecoder.java:250)
	at com.reandroid.apk.ApkModuleXmlDecoder.decodeAndroidManifestXml(ApkModuleXmlDecoder.java:229)
	at com.reandroid.apk.ApkModuleXmlDecoder.decodeAndroidManifest(ApkModuleXmlDecoder.java:198)
	at com.reandroid.apk.ApkModuleDecoder.decode(ApkModuleDecoder.java:56)
	at com.reandroid.apkeditor.decompile.Decompiler.run(Decompiler.java:71)
	at com.reandroid.apkeditor.decompile.Decompiler.execute(Decompiler.java:210)
	at com.reandroid.apkeditor.Main.execute(Main.java:81)
	at com.reandroid.apkeditor.Main.execute(Main.java:64)
	at com.reandroid.apkeditor.Main.main(Main.java:36)
```

And on build:
```
Exception in thread "main" java.lang.IllegalArgumentException: java.io.IOException: Can not decode without package
	at com.reandroid.apk.xmlencoder.XMLEncodeSource.getBytes(XMLEncodeSource.java:53)
	at com.reandroid.archive.ByteInputSource.openStream(ByteInputSource.java:38)
	at com.reandroid.apk.ApkModule.getAndroidManifest(ApkModule.java:787)
	at com.reandroid.apkeditor.smali.SmaliCompiler.buildDexFiles(SmaliCompiler.java:54)
	at com.reandroid.apk.ApkModuleEncoder.encodeDexFiles(ApkModuleEncoder.java:152)
	at com.reandroid.apk.ApkModuleEncoder.scanDirectory(ApkModuleEncoder.java:45)
	at com.reandroid.apkeditor.compile.Builder.buildXml(Builder.java:116)
	at com.reandroid.apkeditor.compile.Builder.run(Builder.java:47)
	at com.reandroid.apkeditor.compile.Builder.execute(Builder.java:181)
	at com.reandroid.apkeditor.Main.execute(Main.java:85)
	at com.reandroid.apkeditor.Main.execute(Main.java:64)
	at com.reandroid.apkeditor.Main.main(Main.java:36)
Caused by: java.io.IOException: Can not decode without package
	at com.reandroid.arsc.chunk.xml.ResXmlDocument.parse(ResXmlDocument.java:470)
	at com.reandroid.apk.xmlencoder.XMLEncodeSource.encode(XMLEncodeSource.java:77)
	at com.reandroid.apk.xmlencoder.XMLEncodeSource.getArray(XMLEncodeSource.java:65)
Caused by: java.io.IOException: Can not decode without package

	at com.reandroid.apk.xmlencoder.XMLEncodeSource.getBytes(XMLEncodeSource.java:51)
	... 11 more
```