### PR TITLE
Support all versions of Android

### DIFF
--- a/src/main/java/android/Base64.java
+++ b/src/main/java/android/Base64.java
@@ -1,0 +1,739 @@
+package android;
+
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.UnsupportedEncodingException;
+
+/**
+ * Utilities for encoding and decoding the Base64 representation of
+ * binary data.  See RFCs <a
+ * href="http://www.ietf.org/rfc/rfc2045.txt">2045</a> and <a
+ * href="http://www.ietf.org/rfc/rfc3548.txt">3548</a>.
+ */
+public class Base64 {
+    /**
+     * Default values for encoder/decoder flags.
+     */
+    public static final int DEFAULT = 0;
+
+    /**
+     * Encoder flag bit to omit the padding '=' characters at the end
+     * of the output (if any).
+     */
+    public static final int NO_PADDING = 1;
+
+    /**
+     * Encoder flag bit to omit all line terminators (i.e., the output
+     * will be on one long line).
+     */
+    public static final int NO_WRAP = 2;
+
+    /**
+     * Encoder flag bit to indicate lines should be terminated with a
+     * CRLF pair instead of just an LF.  Has no effect if {@code
+     * NO_WRAP} is specified as well.
+     */
+    public static final int CRLF = 4;
+
+    /**
+     * Encoder/decoder flag bit to indicate using the "URL and
+     * filename safe" variant of Base64 (see RFC 3548 section 4) where
+     * {@code -} and {@code _} are used in place of {@code +} and
+     * {@code /}.
+     */
+    public static final int URL_SAFE = 8;
+
+    //  --------------------------------------------------------
+    //  shared code
+    //  --------------------------------------------------------
+
+    /* package */ static abstract class Coder {
+        public byte[] output;
+        public int op;
+
+        /**
+         * Encode/decode another block of input data.  this.output is
+         * provided by the caller, and must be big enough to hold all
+         * the coded data.  On exit, this.opwill be set to the length
+         * of the coded data.
+         *
+         * @param finish true if this is the final call to process for
+         *               this object.  Will finalize the coder state and
+         *               include any final bytes in the output.
+         * @return true if the input so far is good; false if some
+         * error has been detected in the input stream..
+         */
+        public abstract boolean process(byte[] input, int offset, int len, boolean finish);
+
+        /**
+         * @return the maximum number of bytes a call to process()
+         * could produce for the given number of input bytes.  This may
+         * be an overestimate.
+         */
+        public abstract int maxOutputSize(int len);
+    }
+
+    //  --------------------------------------------------------
+    //  decoding
+    //  --------------------------------------------------------
+
+    /**
+     * Decode the Base64-encoded data in input and return the data in
+     * a new byte array.
+     *
+     * <p>The padding '=' characters at the end are considered optional, but
+     * if any are present, there must be the correct number of them.
+     *
+     * @param str   the input String to decode, which is converted to
+     *              bytes using the default charset
+     * @param flags controls certain features of the decoded output.
+     *              Pass {@code DEFAULT} to decode standard Base64.
+     * @throws IllegalArgumentException if the input contains
+     *                                  incorrect padding
+     */
+    public static byte[] decode(String str, int flags) {
+        return decode(str.getBytes(), flags);
+    }
+
+    /**
+     * Decode the Base64-encoded data in input and return the data in
+     * a new byte array.
+     *
+     * <p>The padding '=' characters at the end are considered optional, but
+     * if any are present, there must be the correct number of them.
+     *
+     * @param input the input array to decode
+     * @param flags controls certain features of the decoded output.
+     *              Pass {@code DEFAULT} to decode standard Base64.
+     * @throws IllegalArgumentException if the input contains
+     *                                  incorrect padding
+     */
+    public static byte[] decode(byte[] input, int flags) {
+        return decode(input, 0, input.length, flags);
+    }
+
+    /**
+     * Decode the Base64-encoded data in input and return the data in
+     * a new byte array.
+     *
+     * <p>The padding '=' characters at the end are considered optional, but
+     * if any are present, there must be the correct number of them.
+     *
+     * @param input  the data to decode
+     * @param offset the position within the input array at which to start
+     * @param len    the number of bytes of input to decode
+     * @param flags  controls certain features of the decoded output.
+     *               Pass {@code DEFAULT} to decode standard Base64.
+     * @throws IllegalArgumentException if the input contains
+     *                                  incorrect padding
+     */
+    public static byte[] decode(byte[] input, int offset, int len, int flags) {
+        // Allocate space for the most data the input could represent.
+        // (It could contain less if it contains whitespace, etc.)
+        Decoder decoder = new Decoder(flags, new byte[len * 3 / 4]);
+
+        if (!decoder.process(input, offset, len, true)) {
+            throw new IllegalArgumentException("bad base-64");
+        }
+
+        // Maybe we got lucky and allocated exactly enough output space.
+        if (decoder.op == decoder.output.length) {
+            return decoder.output;
+        }
+
+        // Need to shorten the array, so allocate a new one of the
+        // right size and copy.
+        byte[] temp = new byte[decoder.op];
+        System.arraycopy(decoder.output, 0, temp, 0, decoder.op);
+        return temp;
+    }
+
+    /* package */ static class Decoder extends Coder {
+        /**
+         * Lookup table for turning bytes into their position in the
+         * Base64 alphabet.
+         */
+        private static final int DECODE[] = {
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63,
+                52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -2, -1, -1,
+                -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+                15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1,
+                -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+                41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        };
+
+        /**
+         * Decode lookup table for the "web safe" variant (RFC 3548
+         * sec. 4) where - and _ replace + and /.
+         */
+        private static final int DECODE_WEBSAFE[] = {
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1,
+                52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -2, -1, -1,
+                -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+                15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, 63,
+                -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+                41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        };
+
+        /**
+         * Non-data values in the DECODE arrays.
+         */
+        private static final int SKIP = -1;
+        private static final int EQUALS = -2;
+
+        /**
+         * States 0-3 are reading through the next input tuple.
+         * State 4 is having read one '=' and expecting exactly
+         * one more.
+         * State 5 is expecting no more data or padding characters
+         * in the input.
+         * State 6 is the error state; an error has been detected
+         * in the input and no future input can "fix" it.
+         */
+        private int state;   // state number (0 to 6)
+        private int value;
+
+        final private int[] alphabet;
+
+        public Decoder(int flags, byte[] output) {
+            this.output = output;
+
+            alphabet = ((flags & URL_SAFE) == 0) ? DECODE : DECODE_WEBSAFE;
+            state = 0;
+            value = 0;
+        }
+
+        /**
+         * @return an overestimate for the number of bytes {@code
+         * len} bytes could decode to.
+         */
+        public int maxOutputSize(int len) {
+            return len * 3 / 4 + 10;
+        }
+
+        /**
+         * Decode another block of input data.
+         *
+         * @return true if the state machine is still healthy.  false if
+         * bad base-64 data has been detected in the input stream.
+         */
+        public boolean process(byte[] input, int offset, int len, boolean finish) {
+            if (this.state == 6) return false;
+
+            int p = offset;
+            len += offset;
+
+            // Using local variables makes the decoder about 12%
+            // faster than if we manipulate the member variables in
+            // the loop.  (Even alphabet makes a measurable
+            // difference, which is somewhat surprising to me since
+            // the member variable is final.)
+            int state = this.state;
+            int value = this.value;
+            int op = 0;
+            final byte[] output = this.output;
+            final int[] alphabet = this.alphabet;
+
+            while (p < len) {
+                // Try the fast path:  we're starting a new tuple and the
+                // next four bytes of the input stream are all data
+                // bytes.  This corresponds to going through states
+                // 0-1-2-3-0.  We expect to use this method for most of
+                // the data.
+                //
+                // If any of the next four bytes of input are non-data
+                // (whitespace, etc.), value will end up negative.  (All
+                // the non-data values in decode are small negative
+                // numbers, so shifting any of them up and or'ing them
+                // together will result in a value with its top bit set.)
+                //
+                // You can remove this whole block and the output should
+                // be the same, just slower.
+                if (state == 0) {
+                    while (p + 4 <= len &&
+                            (value = ((alphabet[input[p] & 0xff] << 18) |
+                                    (alphabet[input[p + 1] & 0xff] << 12) |
+                                    (alphabet[input[p + 2] & 0xff] << 6) |
+                                    (alphabet[input[p + 3] & 0xff]))) >= 0) {
+                        output[op + 2] = (byte) value;
+                        output[op + 1] = (byte) (value >> 8);
+                        output[op] = (byte) (value >> 16);
+                        op += 3;
+                        p += 4;
+                    }
+                    if (p >= len) break;
+                }
+
+                // The fast path isn't available -- either we've read a
+                // partial tuple, or the next four input bytes aren't all
+                // data, or whatever.  Fall back to the slower state
+                // machine implementation.
+
+                int d = alphabet[input[p++] & 0xff];
+
+                switch (state) {
+                    case 0:
+                        if (d >= 0) {
+                            value = d;
+                            ++state;
+                        } else if (d != SKIP) {
+                            this.state = 6;
+                            return false;
+                        }
+                        break;
+
+                    case 1:
+                        if (d >= 0) {
+                            value = (value << 6) | d;
+                            ++state;
+                        } else if (d != SKIP) {
+                            this.state = 6;
+                            return false;
+                        }
+                        break;
+
+                    case 2:
+                        if (d >= 0) {
+                            value = (value << 6) | d;
+                            ++state;
+                        } else if (d == EQUALS) {
+                            // Emit the last (partial) output tuple;
+                            // expect exactly one more padding character.
+                            output[op++] = (byte) (value >> 4);
+                            state = 4;
+                        } else if (d != SKIP) {
+                            this.state = 6;
+                            return false;
+                        }
+                        break;
+
+                    case 3:
+                        if (d >= 0) {
+                            // Emit the output triple and return to state 0.
+                            value = (value << 6) | d;
+                            output[op + 2] = (byte) value;
+                            output[op + 1] = (byte) (value >> 8);
+                            output[op] = (byte) (value >> 16);
+                            op += 3;
+                            state = 0;
+                        } else if (d == EQUALS) {
+                            // Emit the last (partial) output tuple;
+                            // expect no further data or padding characters.
+                            output[op + 1] = (byte) (value >> 2);
+                            output[op] = (byte) (value >> 10);
+                            op += 2;
+                            state = 5;
+                        } else if (d != SKIP) {
+                            this.state = 6;
+                            return false;
+                        }
+                        break;
+
+                    case 4:
+                        if (d == EQUALS) {
+                            ++state;
+                        } else if (d != SKIP) {
+                            this.state = 6;
+                            return false;
+                        }
+                        break;
+
+                    case 5:
+                        if (d != SKIP) {
+                            this.state = 6;
+                            return false;
+                        }
+                        break;
+                }
+            }
+
+            if (!finish) {
+                // We're out of input, but a future call could provide
+                // more.
+                this.state = state;
+                this.value = value;
+                this.op = op;
+                return true;
+            }
+
+            // Done reading input.  Now figure out where we are left in
+            // the state machine and finish up.
+
+            switch (state) {
+                case 0:
+                    // Output length is a multiple of three.  Fine.
+                    break;
+                case 1:
+                    // Read one extra input byte, which isn't enough to
+                    // make another output byte.  Illegal.
+                    this.state = 6;
+                    return false;
+                case 2:
+                    // Read two extra input bytes, enough to emit 1 more
+                    // output byte.  Fine.
+                    output[op++] = (byte) (value >> 4);
+                    break;
+                case 3:
+                    // Read three extra input bytes, enough to emit 2 more
+                    // output bytes.  Fine.
+                    output[op++] = (byte) (value >> 10);
+                    output[op++] = (byte) (value >> 2);
+                    break;
+                case 4:
+                    // Read one padding '=' when we expected 2.  Illegal.
+                    this.state = 6;
+                    return false;
+                case 5:
+                    // Read all the padding '='s we expected and no more.
+                    // Fine.
+                    break;
+            }
+
+            this.state = state;
+            this.op = op;
+            return true;
+        }
+    }
+
+    //  --------------------------------------------------------
+    //  encoding
+    //  --------------------------------------------------------
+
+    /**
+     * Base64-encode the given data and return a newly allocated
+     * String with the result.
+     *
+     * @param input the data to encode
+     * @param flags controls certain features of the encoded output.
+     *              Passing {@code DEFAULT} results in output that
+     *              adheres to RFC 2045.
+     */
+    public static String encodeToString(byte[] input, int flags) {
+        try {
+            return new String(encode(input, flags), "US-ASCII");
+        } catch (UnsupportedEncodingException e) {
+            // US-ASCII is guaranteed to be available.
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Base64-encode the given data and return a newly allocated
+     * String with the result.
+     *
+     * @param input  the data to encode
+     * @param offset the position within the input array at which to
+     *               start
+     * @param len    the number of bytes of input to encode
+     * @param flags  controls certain features of the encoded output.
+     *               Passing {@code DEFAULT} results in output that
+     *               adheres to RFC 2045.
+     */
+    public static String encodeToString(byte[] input, int offset, int len, int flags) {
+        try {
+            return new String(encode(input, offset, len, flags), "US-ASCII");
+        } catch (UnsupportedEncodingException e) {
+            // US-ASCII is guaranteed to be available.
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Base64-encode the given data and return a newly allocated
+     * byte[] with the result.
+     *
+     * @param input the data to encode
+     * @param flags controls certain features of the encoded output.
+     *              Passing {@code DEFAULT} results in output that
+     *              adheres to RFC 2045.
+     */
+    public static byte[] encode(byte[] input, int flags) {
+        return encode(input, 0, input.length, flags);
+    }
+
+    /**
+     * Base64-encode the given data and return a newly allocated
+     * byte[] with the result.
+     *
+     * @param input  the data to encode
+     * @param offset the position within the input array at which to
+     *               start
+     * @param len    the number of bytes of input to encode
+     * @param flags  controls certain features of the encoded output.
+     *               Passing {@code DEFAULT} results in output that
+     *               adheres to RFC 2045.
+     */
+    public static byte[] encode(byte[] input, int offset, int len, int flags) {
+        Encoder encoder = new Encoder(flags, null);
+
+        // Compute the exact length of the array we will produce.
+        int output_len = len / 3 * 4;
+
+        // Account for the tail of the data and the padding bytes, if any.
+        if (encoder.do_padding) {
+            if (len % 3 > 0) {
+                output_len += 4;
+            }
+        } else {
+            switch (len % 3) {
+                case 0:
+                    break;
+                case 1:
+                    output_len += 2;
+                    break;
+                case 2:
+                    output_len += 3;
+                    break;
+            }
+        }
+
+        // Account for the newlines, if any.
+        if (encoder.do_newline && len > 0) {
+            output_len += (((len - 1) / (3 * Encoder.LINE_GROUPS)) + 1) *
+                    (encoder.do_cr ? 2 : 1);
+        }
+
+        encoder.output = new byte[output_len];
+        encoder.process(input, offset, len, true);
+
+        assert encoder.op == output_len;
+
+        return encoder.output;
+    }
+
+    /* package */ static class Encoder extends Coder {
+        /**
+         * Emit a new line every this many output tuples.  Corresponds to
+         * a 76-character line length (the maximum allowable according to
+         * <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045</a>).
+         */
+        public static final int LINE_GROUPS = 19;
+
+        /**
+         * Lookup table for turning Base64 alphabet positions (6 bits)
+         * into output bytes.
+         */
+        private static final byte ENCODE[] = {
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+                'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+                'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+                'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/',
+        };
+
+        /**
+         * Lookup table for turning Base64 alphabet positions (6 bits)
+         * into output bytes.
+         */
+        private static final byte ENCODE_WEBSAFE[] = {
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+                'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+                'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+                'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '_',
+        };
+
+        final private byte[] tail;
+        /* package */ int tailLen;
+        private int count;
+
+        final public boolean do_padding;
+        final public boolean do_newline;
+        final public boolean do_cr;
+        final private byte[] alphabet;
+
+        public Encoder(int flags, byte[] output) {
+            this.output = output;
+
+            do_padding = (flags & NO_PADDING) == 0;
+            do_newline = (flags & NO_WRAP) == 0;
+            do_cr = (flags & CRLF) != 0;
+            alphabet = ((flags & URL_SAFE) == 0) ? ENCODE : ENCODE_WEBSAFE;
+
+            tail = new byte[2];
+            tailLen = 0;
+
+            count = do_newline ? LINE_GROUPS : -1;
+        }
+
+        /**
+         * @return an overestimate for the number of bytes {@code
+         * len} bytes could encode to.
+         */
+        public int maxOutputSize(int len) {
+            return len * 8 / 5 + 10;
+        }
+
+        public boolean process(byte[] input, int offset, int len, boolean finish) {
+            // Using local variables makes the encoder about 9% faster.
+            final byte[] alphabet = this.alphabet;
+            final byte[] output = this.output;
+            int op = 0;
+            int count = this.count;
+
+            int p = offset;
+            len += offset;
+            int v = -1;
+
+            // First we need to concatenate the tail of the previous call
+            // with any input bytes available now and see if we can empty
+            // the tail.
+
+            switch (tailLen) {
+                case 0:
+                    // There was no tail.
+                    break;
+
+                case 1:
+                    if (p + 2 <= len) {
+                        // A 1-byte tail with at least 2 bytes of
+                        // input available now.
+                        v = ((tail[0] & 0xff) << 16) |
+                                ((input[p++] & 0xff) << 8) |
+                                (input[p++] & 0xff);
+                        tailLen = 0;
+                    }
+                    ;
+                    break;
+
+                case 2:
+                    if (p + 1 <= len) {
+                        // A 2-byte tail with at least 1 byte of input.
+                        v = ((tail[0] & 0xff) << 16) |
+                                ((tail[1] & 0xff) << 8) |
+                                (input[p++] & 0xff);
+                        tailLen = 0;
+                    }
+                    break;
+            }
+
+            if (v != -1) {
+                output[op++] = alphabet[(v >> 18) & 0x3f];
+                output[op++] = alphabet[(v >> 12) & 0x3f];
+                output[op++] = alphabet[(v >> 6) & 0x3f];
+                output[op++] = alphabet[v & 0x3f];
+                if (--count == 0) {
+                    if (do_cr) output[op++] = '\r';
+                    output[op++] = '\n';
+                    count = LINE_GROUPS;
+                }
+            }
+
+            // At this point either there is no tail, or there are fewer
+            // than 3 bytes of input available.
+
+            // The main loop, turning 3 input bytes into 4 output bytes on
+            // each iteration.
+            while (p + 3 <= len) {
+                v = ((input[p] & 0xff) << 16) |
+                        ((input[p + 1] & 0xff) << 8) |
+                        (input[p + 2] & 0xff);
+                output[op] = alphabet[(v >> 18) & 0x3f];
+                output[op + 1] = alphabet[(v >> 12) & 0x3f];
+                output[op + 2] = alphabet[(v >> 6) & 0x3f];
+                output[op + 3] = alphabet[v & 0x3f];
+                p += 3;
+                op += 4;
+                if (--count == 0) {
+                    if (do_cr) output[op++] = '\r';
+                    output[op++] = '\n';
+                    count = LINE_GROUPS;
+                }
+            }
+
+            if (finish) {
+                // Finish up the tail of the input.  Note that we need to
+                // consume any bytes in tail before any bytes
+                // remaining in input; there should be at most two bytes
+                // total.
+
+                if (p - tailLen == len - 1) {
+                    int t = 0;
+                    v = ((tailLen > 0 ? tail[t++] : input[p++]) & 0xff) << 4;
+                    tailLen -= t;
+                    output[op++] = alphabet[(v >> 6) & 0x3f];
+                    output[op++] = alphabet[v & 0x3f];
+                    if (do_padding) {
+                        output[op++] = '=';
+                        output[op++] = '=';
+                    }
+                    if (do_newline) {
+                        if (do_cr) output[op++] = '\r';
+                        output[op++] = '\n';
+                    }
+                } else if (p - tailLen == len - 2) {
+                    int t = 0;
+                    v = (((tailLen > 1 ? tail[t++] : input[p++]) & 0xff) << 10) |
+                            (((tailLen > 0 ? tail[t++] : input[p++]) & 0xff) << 2);
+                    tailLen -= t;
+                    output[op++] = alphabet[(v >> 12) & 0x3f];
+                    output[op++] = alphabet[(v >> 6) & 0x3f];
+                    output[op++] = alphabet[v & 0x3f];
+                    if (do_padding) {
+                        output[op++] = '=';
+                    }
+                    if (do_newline) {
+                        if (do_cr) output[op++] = '\r';
+                        output[op++] = '\n';
+                    }
+                } else if (do_newline && op > 0 && count != LINE_GROUPS) {
+                    if (do_cr) output[op++] = '\r';
+                    output[op++] = '\n';
+                }
+
+                assert tailLen == 0;
+                assert p == len;
+            } else {
+                // Save the leftovers in tail to be consumed on the next
+                // call to encodeInternal.
+
+                if (p == len - 1) {
+                    tail[tailLen++] = input[p];
+                } else if (p == len - 2) {
+                    tail[tailLen++] = input[p];
+                    tail[tailLen++] = input[p + 1];
+                }
+            }
+
+            this.op = op;
+            this.count = count;
+
+            return true;
+        }
+    }
+
+    private Base64() {
+    }   // don't instantiate
+}

--- a/src/main/java/android/content/res/XmlResourceParser.java
+++ b/src/main/java/android/content/res/XmlResourceParser.java
@@ -19,7 +19,9 @@ package android.content.res;
 import android.util.AttributeSet;
 import org.xmlpull.v1.XmlPullParser;
 
-public interface XmlResourceParser extends XmlPullParser, AttributeSet, AutoCloseable {
+import java.io.Closeable;
+
+public interface XmlResourceParser extends XmlPullParser, AttributeSet, Closeable {
     String getAttributeNamespace (int index);
     void close();
 }

--- a/src/main/java/com/reandroid/apk/ApkModule.java
+++ b/src/main/java/com/reandroid/apk/ApkModule.java
@@ -41,7 +41,7 @@ import com.reandroid.xml.XMLElement;
 
 import java.io.*;
 import java.util.*;
-import java.util.function.Predicate;
+
 import java.util.zip.ZipEntry;
 
 public class ApkModule implements ApkFile, Closeable {
@@ -634,7 +634,7 @@ public class ApkModule implements ApkFile, Closeable {
         if (tableBlock != null) {
             TableStringPool stringPool = tableBlock.getStringPool();
             Iterator<TableString> iterator = stringPool.getAll(path);
-            Predicate<Entry> filter = entry -> entry.isScalar() &&
+            org.apache.commons.collections4.Predicate<Entry> filter = entry -> entry.isScalar() &&
                     TypeBlock.canHaveResourceFile(entry.getTypeName());
             while (iterator.hasNext()) {
                 results.addAll(iterator.next().getEntries(filter));

--- a/src/main/java/com/reandroid/apk/ApkModuleXmlDecoder.java
+++ b/src/main/java/com/reandroid/apk/ApkModuleXmlDecoder.java
@@ -34,9 +34,9 @@ import org.xmlpull.v1.XmlSerializer;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
-import java.util.function.Predicate;
 
-public class ApkModuleXmlDecoder extends ApkModuleDecoder implements Predicate<Entry> {
+// not used
+public class ApkModuleXmlDecoder extends ApkModuleDecoder implements org.apache.commons.collections4.Predicate<Entry> {
     private final Map<Integer, Set<ResConfig>> decodedEntries;
     private boolean keepResPath;
 
@@ -305,7 +305,7 @@ public class ApkModuleXmlDecoder extends ApkModuleDecoder implements Predicate<E
         overlayableList.serialize(serializer);
     }
     @Override
-    public boolean test(Entry entry) {
+    public boolean evaluate(Entry entry) {
         return containsDecodedEntry(entry);
     }
 }

--- a/src/main/java/com/reandroid/apk/ApkUtil.java
+++ b/src/main/java/com/reandroid/apk/ApkUtil.java
@@ -17,6 +17,8 @@ package com.reandroid.apk;
 
 import com.reandroid.arsc.chunk.PackageBlock;
 import com.reandroid.utils.CompareUtil;
+import com.reandroid.utils.StringsUtil;
+import com.reandroid.utils.collection.CollectionUtil;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -26,7 +28,7 @@ public class ApkUtil {
     public static String replaceRootDir(String path, String dirName){
         int i=path.indexOf('/')+1;
         path=path.substring(i);
-        if(dirName != null && dirName.length()>0){
+        if(!StringsUtil.isEmpty(dirName)){
             if(!dirName.endsWith("/")){
                 dirName=dirName+"/";
             }
@@ -103,7 +105,7 @@ public class ApkUtil {
                 results.add(dir);
             }
         }
-        results.sort(CompareUtil.getComparableComparator());
+        java.util.Collections.sort(results, CompareUtil.getComparableComparator());
         return results;
     }
     public static List<File> listPublicXmlFiles(File resourcesDirectory){
@@ -121,7 +123,7 @@ public class ApkUtil {
                 }
             }
         }
-        results.sort(CompareUtil.getComparableComparator());
+        java.util.Collections.sort(results, CompareUtil.getComparableComparator());
         return results;
     }
     private static File getPublicXmlFile(File resDir){
@@ -158,7 +160,7 @@ public class ApkUtil {
                 results.add(dir);
             }
         }
-        results.sort(CompareUtil.getComparableComparator());
+        java.util.Collections.sort(results, CompareUtil.getComparableComparator());
         return results;
     }
     public static boolean isValuesDirectoryName(String name, boolean checkVariant){

--- a/src/main/java/com/reandroid/apk/DexFileInputSource.java
+++ b/src/main/java/com/reandroid/apk/DexFileInputSource.java
@@ -19,6 +19,7 @@ import com.reandroid.archive.InputSource;
 import com.reandroid.archive.RenamedInputSource;
 import com.reandroid.utils.CompareUtil;
 import com.reandroid.utils.ObjectsUtil;
+import com.reandroid.utils.collection.CollectionUtil;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -38,16 +39,11 @@ public class DexFileInputSource extends RenamedInputSource<InputSource> implemen
     }
 
     public static void sort(List<DexFileInputSource> sourceList){
-        sourceList.sort(CompareUtil.getComparableComparator());
+        java.util.Collections.sort(sourceList, CompareUtil.getComparableComparator());
     }
 
     public static void sortDexFiles(List<File> fileList){
-        fileList.sort(new Comparator<File>() {
-            @Override
-            public int compare(File file1, File file2) {
-                return InputSource.compareDex(file1.getName(), file2.getName());
-            }
-        });
+        java.util.Collections.sort(fileList, (Comparator<File>) (file1, file2) -> InputSource.compareDex(file1.getName(), file2.getName()));
     }
     public static List<File> listDexFiles(File dir){
         List<File> results = new ArrayList<>();

--- a/src/main/java/com/reandroid/apk/FrameworkOptimizer.java
+++ b/src/main/java/com/reandroid/apk/FrameworkOptimizer.java
@@ -31,7 +31,7 @@ import com.reandroid.arsc.value.*;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.function.Predicate;
+
 import java.util.zip.ZipEntry;
 
  public class FrameworkOptimizer {
@@ -133,9 +133,9 @@ import java.util.zip.ZipEntry;
         logMessage("Compressing manifest ...");
         int prev = manifestBlock.countBytes();
         ResXmlElement manifest = manifestBlock.getDocumentElement();
-        manifest.removeIf(new Predicate<ResXmlNode>() {
+        manifest.removeIf(new org.apache.commons.collections4.Predicate<ResXmlNode>() {
             @Override
-            public boolean test(ResXmlNode xmlNode) {
+            public boolean evaluate(ResXmlNode xmlNode) {
                 return !(xmlNode instanceof ResXmlElement) ||
                         !((ResXmlElement) xmlNode).equalsName(AndroidManifest.TAG_application);
             }

--- a/src/main/java/com/reandroid/apk/ResFile.java
+++ b/src/main/java/com/reandroid/apk/ResFile.java
@@ -33,7 +33,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Predicate;
+
 
 public class ResFile implements Iterable<Entry> {
 
@@ -53,7 +53,7 @@ public class ResFile implements Iterable<Entry> {
     public Iterator<Entry> iterator() {
         return getEntries().iterator();
     }
-    public Iterator<Entry> iterator(Predicate<? super Entry> filter) {
+    public Iterator<Entry> iterator(org.apache.commons.collections4.Predicate<? super Entry> filter) {
         return FilterIterator.of(iterator(), filter);
     }
     public int size() {

--- a/src/main/java/com/reandroid/apk/xmlencoder/EncodeUtil.java
+++ b/src/main/java/com/reandroid/apk/xmlencoder/EncodeUtil.java
@@ -15,18 +15,19 @@
  */
 package com.reandroid.apk.xmlencoder;
 
+import com.reandroid.utils.collection.CollectionUtil;
+
 import java.io.File;
 import java.util.Comparator;
 import java.util.List;
 
 public class EncodeUtil {
     public static void sortValuesXml(List<File> fileList){
-        Comparator<File> cmp= (f1, f2) -> {
+        java.util.Collections.sort(fileList, (Comparator<File>) (f1, f2) -> {
             String n1=getValuesXmlCompare(f1);
             String n2=getValuesXmlCompare(f2);
             return n1.compareTo(n2);
-        };
-        fileList.sort(cmp);
+        });
     }
     private static String getValuesXmlCompare(File file){
         String name=file.getName().toLowerCase();

--- a/src/main/java/com/reandroid/archive/Archive.java
+++ b/src/main/java/com/reandroid/archive/Archive.java
@@ -30,7 +30,7 @@ import com.reandroid.utils.io.IOUtil;
 
 import java.io.*;
 import java.util.*;
-import java.util.function.Predicate;
+
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
 
@@ -60,7 +60,7 @@ public abstract class Archive<T extends ZipInput> implements Closeable {
         // TODO: make InputSource for directory entry
         return getInputSources(ArchiveEntry::isFile);
     }
-    public InputSource[] getInputSources(Predicate<? super ArchiveEntry> filter){
+    public InputSource[] getInputSources(org.apache.commons.collections4.Predicate<? super ArchiveEntry> filter){
         Iterator<InputSource> iterator = ComputeIterator.of(iterator(filter), this::createInputSource);
         List<InputSource> sourceList = CollectionUtil.toList(iterator);
         return sourceList.toArray(new InputSource[sourceList.size()]);
@@ -126,7 +126,7 @@ public abstract class Archive<T extends ZipInput> implements Closeable {
     public Iterator<ArchiveEntry> iterator() {
         return new ArrayIterator<>(entryList);
     }
-    public Iterator<ArchiveEntry> iterator(Predicate<? super ArchiveEntry> filter) {
+    public Iterator<ArchiveEntry> iterator(org.apache.commons.collections4.Predicate<? super ArchiveEntry> filter) {
         return new ArrayIterator<>(entryList, filter);
     }
     public int size(){
@@ -145,10 +145,10 @@ public abstract class Archive<T extends ZipInput> implements Closeable {
     public int extractAll(File dir, APKLogger logger) throws IOException {
         return extractAll(dir, null, logger);
     }
-    public int extractAll(File dir, Predicate<ArchiveEntry> filter) throws IOException {
+    public int extractAll(File dir, org.apache.commons.collections4.Predicate<ArchiveEntry> filter) throws IOException {
         return extractAll(dir, filter, null);
     }
-    public int extractAll(File dir, Predicate<ArchiveEntry> filter, APKLogger logger) throws IOException {
+    public int extractAll(File dir, org.apache.commons.collections4.Predicate<ArchiveEntry> filter, APKLogger logger) throws IOException {
         Iterator<ArchiveEntry> iterator = iterator(filter);
         int result = 0;
         while (iterator.hasNext()){

--- a/src/main/java/com/reandroid/archive/PathTree.java
+++ b/src/main/java/com/reandroid/archive/PathTree.java
@@ -75,7 +75,7 @@ public class PathTree<T> implements Comparable<PathTree<?>>, Iterable<PathTree<T
     @SuppressWarnings("unchecked")
     public void sort(Comparator<? super PathTree<?>> comparator, boolean recursive){
         LinkedHashMap<String, PathTree<T>> elementsMap = this.elementsMap;
-        if(elementsMap.size() == 0){
+        if(elementsMap.isEmpty()){
             return;
         }
         PathTree<?>[] elements = elementsMap.values().toArray(new PathTree<?>[0]);

--- a/src/main/java/com/reandroid/archive/ZipEntryMap.java
+++ b/src/main/java/com/reandroid/archive/ZipEntryMap.java
@@ -20,7 +20,7 @@ import com.reandroid.utils.collection.ArraySort;
 import com.reandroid.utils.collection.CollectionUtil;
 
 import java.util.*;
-import java.util.function.Predicate;
+
 import java.util.regex.Pattern;
 
 public class ZipEntryMap implements Comparator<InputSource>, Iterable<InputSource>{
@@ -47,11 +47,11 @@ public class ZipEntryMap implements Comparator<InputSource>, Iterable<InputSourc
         this.moduleName = moduleName;
     }
 
-    public Iterator<InputSource> iterator(Predicate<? super InputSource> filter){
+    public Iterator<InputSource> iterator(org.apache.commons.collections4.Predicate<? super InputSource> filter){
         return ArrayIterator.of(toArray(), filter);
     }
-    public Iterator<InputSource> iteratorWithPath(Predicate<? super String> filter){
-        return iterator(inputSource -> filter.test(inputSource.getAlias()));
+    public Iterator<InputSource> iteratorWithPath(org.apache.commons.collections4.Predicate<? super String> filter){
+        return iterator(inputSource -> filter.evaluate(inputSource.getAlias()));
     }
     public Iterator<InputSource> withinDirectory(String directory) {
         return withinDirectory(directory, true);
@@ -107,7 +107,7 @@ public class ZipEntryMap implements Comparator<InputSource>, Iterable<InputSourc
             return sources;
         }
     }
-    public InputSource[] toArray(Predicate<? super InputSource> filter){
+    public InputSource[] toArray(org.apache.commons.collections4.Predicate<? super InputSource> filter){
         return CollectionUtil.toList(iterator(filter)).toArray(new InputSource[0]);
     }
     private void onChanged(boolean changed){
@@ -137,7 +137,7 @@ public class ZipEntryMap implements Comparator<InputSource>, Iterable<InputSourc
             onChanged(changed);
         }
     }
-    public void removeIf(Predicate<? super InputSource> filter){
+    public void removeIf(org.apache.commons.collections4.Predicate<? super InputSource> filter){
         Iterator<InputSource> iterator = iterator(filter);
         while (iterator.hasNext()){
             remove(iterator.next());

--- a/src/main/java/com/reandroid/archive/block/CentralEntryHeader.java
+++ b/src/main/java/com/reandroid/archive/block/CentralEntryHeader.java
@@ -17,6 +17,7 @@ package com.reandroid.archive.block;
 
 import com.reandroid.archive.ZipSignature;
 import com.reandroid.utils.HexUtil;
+import com.reandroid.utils.StringsUtil;
 import com.reandroid.utils.io.FilePermissions;
 
 import java.io.IOException;
@@ -79,7 +80,7 @@ public class CentralEntryHeader extends CommonHeader {
         if(comment==null){
             comment="";
         }
-        byte[] strBytes = comment.getBytes(StandardCharsets.UTF_8);
+        byte[] strBytes = StringsUtil.getBytesOfString(comment, "UTF-8");
         int length = strBytes.length;
         setCommentLength(length);
         if(length==0){

--- a/src/main/java/com/reandroid/archive/block/CommonHeader.java
+++ b/src/main/java/com/reandroid/archive/block/CommonHeader.java
@@ -18,13 +18,11 @@ package com.reandroid.archive.block;
 import com.reandroid.archive.Archive;
 import com.reandroid.archive.ZipSignature;
 import com.reandroid.utils.HexUtil;
+import com.reandroid.utils.StringsUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Calendar;
 import java.util.Date;
-import java.util.GregorianCalendar;
 
 public abstract class CommonHeader extends ZipHeader {
     private final int offsetFileName;
@@ -293,7 +291,7 @@ public abstract class CommonHeader extends ZipHeader {
         if(fileName==null){
             fileName="";
         }
-        byte[] nameBytes = fileName.getBytes(StandardCharsets.UTF_8);
+        byte[] nameBytes = StringsUtil.getBytesOfString(fileName, "UTF-8");
         getGeneralPurposeFlag().setUtf8(true, false);
         int length = nameBytes.length;
         setFileNameLength(length);
@@ -325,7 +323,7 @@ public abstract class CommonHeader extends ZipHeader {
         if(length>max){
             length = max;
         }
-        return new String(bytes, offset, length, StandardCharsets.UTF_8);
+        return new String(bytes, offset, length, com.reandroid.utils.StringsUtil.UTF_8);
     }
     public String decodeComment(){
         int length = getExtraLength();
@@ -338,7 +336,7 @@ public abstract class CommonHeader extends ZipHeader {
         if(length>max){
             length = max;
         }
-        return new String(bytes, offset, length, StandardCharsets.UTF_8);
+        return new String(bytes, offset, length, com.reandroid.utils.StringsUtil.UTF_8);
     }
     void onUtf8Changed(boolean oldValue){
         String str = mFileName;

--- a/src/main/java/com/reandroid/archive/writer/OutputSource.java
+++ b/src/main/java/com/reandroid/archive/writer/OutputSource.java
@@ -49,8 +49,15 @@ class OutputSource {
         CountingOutputStream<DeflaterOutputStream> deflateCounter = null;
 
         if(inputSource.getMethod() != Archive.STORED){
-            DeflaterOutputStream deflaterInputStream =
-                    new DeflaterOutputStream(rawCounter, new Deflater(Deflater.DEFAULT_COMPRESSION, true), true);
+            DeflaterOutputStream deflaterInputStream;
+            try {
+                //Hack way to do this without checking Build.VERSION.SDK_INT
+                deflaterInputStream = new DeflaterOutputStream(
+                        rawCounter, new Deflater(Deflater.DEFAULT_COMPRESSION, true), true);
+            } catch (Exception e) {
+                deflaterInputStream =  new DeflaterOutputStream(
+                        rawCounter, new Deflater(Deflater.DEFAULT_COMPRESSION, true));
+            }
             deflateCounter = new CountingOutputStream<>(deflaterInputStream, false);
         }
         if(deflateCounter != null){

--- a/src/main/java/com/reandroid/arsc/array/TypeBlockArray.java
+++ b/src/main/java/com/reandroid/arsc/array/TypeBlockArray.java
@@ -36,7 +36,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.function.Predicate;
+
 
 public class TypeBlockArray extends BlockArray<TypeBlock>
         implements JSONConvert<JSONArray>, Comparator<TypeBlock> {
@@ -237,9 +237,9 @@ public class TypeBlockArray extends BlockArray<TypeBlock>
         return super.iterator(NON_EMPTY_TESTER);
     }
     public Iterator<TypeBlock> iterator(ResConfig resConfig){
-        return iterator(new Predicate<TypeBlock>() {
+        return iterator(new org.apache.commons.collections4.Predicate<TypeBlock>() {
             @Override
-            public boolean test(TypeBlock typeBlock) {
+            public boolean evaluate(TypeBlock typeBlock) {
                 return typeBlock.getResConfig().equals(resConfig);
             }
         });
@@ -404,9 +404,9 @@ public class TypeBlockArray extends BlockArray<TypeBlock>
         return typeBlock1.compareTo(typeBlock2);
     }
 
-    private static final Predicate<TypeBlock> NON_EMPTY_TESTER = new Predicate<TypeBlock>() {
+    private static final org.apache.commons.collections4.Predicate<TypeBlock> NON_EMPTY_TESTER = new org.apache.commons.collections4.Predicate<TypeBlock>() {
         @Override
-        public boolean test(TypeBlock typeBlock) {
+        public boolean evaluate(TypeBlock typeBlock) {
             if(typeBlock == null || typeBlock.isNull()){
                 return false;
             }

--- a/src/main/java/com/reandroid/arsc/base/BlockArray.java
+++ b/src/main/java/com/reandroid/arsc/base/BlockArray.java
@@ -23,7 +23,7 @@ import com.reandroid.utils.collection.FilterIterator;
 
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public abstract class BlockArray<T extends Block> extends BlockList<T>
         implements Creator<T>, ArraySupplier<T> {
@@ -112,7 +112,7 @@ public abstract class BlockArray<T extends Block> extends BlockList<T>
         block.setParent(null);
         block.setIndex(-1);
     }
-    public void trimLastIf(Predicate<? super T> predicate) {
+    public void trimLastIf(org.apache.commons.collections4.Predicate<? super T> predicate) {
         int size = size() - countFromLast(predicate);
         if(size != size()) {
             setSize(size);
@@ -121,10 +121,10 @@ public abstract class BlockArray<T extends Block> extends BlockList<T>
     public void removeNullBlocks() {
         removeIf(nullPredicate());
     }
-    private Predicate<? super T> nullPredicate() {
+    private org.apache.commons.collections4.Predicate<? super T> nullPredicate() {
         return Block::isNull;
     }
-    private Predicate<? super T> nonNullPredicate() {
+    private org.apache.commons.collections4.Predicate<? super T> nonNullPredicate() {
         return block -> !block.isNull();
     }
 
@@ -132,7 +132,7 @@ public abstract class BlockArray<T extends Block> extends BlockList<T>
     public T[] toArray() {
         return super.toArray(newArrayInstance(size()));
     }
-    public T[] toArrayIf(Predicate<? super T> predicate) {
+    public T[] toArrayIf(org.apache.commons.collections4.Predicate<? super T> predicate) {
         return toArrayIf(predicate, getCreator());
     }
 }

--- a/src/main/java/com/reandroid/arsc/chunk/PackageBlock.java
+++ b/src/main/java/com/reandroid/arsc/chunk/PackageBlock.java
@@ -63,7 +63,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Predicate;
+
 
 
 public class PackageBlock extends Chunk<PackageHeader>
@@ -573,9 +573,9 @@ public class PackageBlock extends Chunk<PackageHeader>
     }
 
     private Iterator<SpecTypePair> getAttrSpecs(){
-        return getSpecTypePairArray().iterator(new Predicate<SpecTypePair>() {
+        return getSpecTypePairArray().iterator(new org.apache.commons.collections4.Predicate<SpecTypePair>() {
             @Override
-            public boolean test(SpecTypePair specTypePair) {
+            public boolean evaluate(SpecTypePair specTypePair) {
                 return specTypePair != null && specTypePair.isTypeAttr();
             }
         });

--- a/src/main/java/com/reandroid/arsc/chunk/TableBlock.java
+++ b/src/main/java/com/reandroid/arsc/chunk/TableBlock.java
@@ -42,7 +42,7 @@ import java.io.*;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Predicate;
+
 
 public class TableBlock extends Chunk<TableHeader>
         implements MainChunk, Iterable<PackageBlock>, JSONConvert<JSONObject> {
@@ -340,7 +340,7 @@ public class TableBlock extends Chunk<TableHeader>
     public Iterator<PackageBlock> getPackages(String packageName){
         return new  FilterIterator<PackageBlock>(getPackages()) {
             @Override
-            public boolean test(PackageBlock packageBlock){
+            public boolean evaluate(PackageBlock packageBlock){
                 if(packageName != null && packageName.length() > 0){
                     return packageBlock.packageNameMatches(packageName);
                 }
@@ -354,7 +354,7 @@ public class TableBlock extends Chunk<TableHeader>
         }
         return new FilterIterator<PackageBlock>(getPackages()) {
             @Override
-            public boolean test(PackageBlock packageBlock){
+            public boolean evaluate(PackageBlock packageBlock){
                 return packageId == packageBlock.getId();
             }
         };
@@ -387,7 +387,7 @@ public class TableBlock extends Chunk<TableHeader>
     public Iterator<PackageBlock> getAllPackages(PackageBlock context, String packageName){
         return new  FilterIterator<PackageBlock>(getAllPackages(context)) {
             @Override
-            public boolean test(PackageBlock packageBlock){
+            public boolean evaluate(PackageBlock packageBlock){
                 if(packageName != null){
                     return packageBlock.packageNameMatches(packageName);
                 }
@@ -407,7 +407,7 @@ public class TableBlock extends Chunk<TableHeader>
     public Iterator<PackageBlock> getAllPackages(int packageId){
         return new  FilterIterator<PackageBlock>(getAllPackages()) {
             @Override
-            public boolean test(PackageBlock packageBlock){
+            public boolean evaluate(PackageBlock packageBlock){
                 return packageId == packageBlock.getId();
             }
         };
@@ -415,7 +415,7 @@ public class TableBlock extends Chunk<TableHeader>
     public Iterator<PackageBlock> getAllPackages(String packageName){
         return new  FilterIterator<PackageBlock>(getAllPackages()) {
             @Override
-            public boolean test(PackageBlock packageBlock){
+            public boolean evaluate(PackageBlock packageBlock){
                 if(packageName != null){
                     return packageBlock.packageNameMatches(packageName);
                 }
@@ -494,7 +494,7 @@ public class TableBlock extends Chunk<TableHeader>
         }
         return resolver.resolveWithConfig(referenceId, resConfig);
     }
-    public List<Entry> resolveReference(int referenceId, Predicate<Entry> filter){
+    public List<Entry> resolveReference(int referenceId, org.apache.commons.collections4.Predicate<Entry> filter){
         ReferenceResolver resolver = this.referenceResolver;
         if(resolver == null){
             resolver = new ReferenceResolver(this);

--- a/src/main/java/com/reandroid/arsc/chunk/xml/ResXmlDocumentOrElement.java
+++ b/src/main/java/com/reandroid/arsc/chunk/xml/ResXmlDocumentOrElement.java
@@ -23,7 +23,7 @@ import org.xmlpull.v1.XmlPullParserException;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Predicate;
+
 
 abstract class ResXmlDocumentOrElement extends ResXmlNodeTree {
 
@@ -89,9 +89,9 @@ abstract class ResXmlDocumentOrElement extends ResXmlNodeTree {
             }
         };
     }
-    public boolean removeElementsIf(Predicate<? super ResXmlElement> predicate) {
+    public boolean removeElementsIf(org.apache.commons.collections4.Predicate<? super ResXmlElement> predicate) {
         return removeIf(xmlNode -> (xmlNode instanceof ResXmlElement)
-                && predicate.test((ResXmlElement) xmlNode));
+                && predicate.evaluate((ResXmlElement) xmlNode));
     }
     public void setAttributesUnitSize(int size, boolean recursive) {
         Iterator<ResXmlElement> iterator = getElements();
@@ -112,16 +112,16 @@ abstract class ResXmlDocumentOrElement extends ResXmlNodeTree {
     public List<ResXmlElement> listElements(String name) {
         return CollectionUtil.toList(getElements(name));
     }
-    public Iterator<ResXmlElement> getElements(Predicate<? super ResXmlElement> predicate) {
+    public Iterator<ResXmlElement> getElements(org.apache.commons.collections4.Predicate<? super ResXmlElement> predicate) {
         return iterator(ResXmlElement.class, predicate);
     }
     public Iterator<ResXmlElement> recursiveElements() {
         return recursive(ResXmlElement.class);
     }
-    public Iterator<ResXmlElement> recursiveElements(Predicate<? super ResXmlElement> predicate) {
+    public Iterator<ResXmlElement> recursiveElements(org.apache.commons.collections4.Predicate<? super ResXmlElement> predicate) {
         return recursive(ResXmlElement.class, predicate);
     }
-    public Iterator<ResXmlAttribute> recursiveAttributes(Predicate<? super ResXmlAttribute> predicate) {
+    public Iterator<ResXmlAttribute> recursiveAttributes(org.apache.commons.collections4.Predicate<? super ResXmlAttribute> predicate) {
         return FilterIterator.of(recursiveAttributes(), predicate);
     }
     public Iterator<ResXmlAttribute> recursiveAttributes() {

--- a/src/main/java/com/reandroid/arsc/chunk/xml/ResXmlElement.java
+++ b/src/main/java/com/reandroid/arsc/chunk/xml/ResXmlElement.java
@@ -21,7 +21,7 @@ import org.xmlpull.v1.XmlSerializer;
 
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class ResXmlElement extends ResXmlDocumentOrElement implements Element<ResXmlNode> {
 
@@ -97,7 +97,7 @@ public class ResXmlElement extends ResXmlDocumentOrElement implements Element<Re
     public Iterator<ResXmlAttribute> getAttributes() {
         return getAttributeArray().clonedIterator();
     }
-    public Iterator<ResXmlAttribute> getAttributes(Predicate<? super ResXmlAttribute> predicate) {
+    public Iterator<ResXmlAttribute> getAttributes(org.apache.commons.collections4.Predicate<? super ResXmlAttribute> predicate) {
         return getAttributeArray().iterator(predicate);
     }
     public boolean removeAttribute(ResXmlAttribute attribute) {
@@ -106,7 +106,7 @@ public class ResXmlElement extends ResXmlDocumentOrElement implements Element<Re
     public boolean removeAttributeAt(int index) {
         return getAttributeArray().remove(index) != null;
     }
-    public boolean removeAttributeIf(Predicate<? super ResXmlAttribute> predicate) {
+    public boolean removeAttributeIf(org.apache.commons.collections4.Predicate<? super ResXmlAttribute> predicate) {
         return getAttributeArray().removeIf(predicate);
     }
     public boolean removeAttributesWithId(int resourceId) {
@@ -130,7 +130,7 @@ public class ResXmlElement extends ResXmlDocumentOrElement implements Element<Re
     public boolean removeNamespace(ResXmlNamespace namespace) {
         return getNamespaceList().remove((ResXmlStartNamespace) namespace);
     }
-    public boolean removeNamespaceIf(Predicate<? super ResXmlNamespace> predicate) {
+    public boolean removeNamespaceIf(org.apache.commons.collections4.Predicate<? super ResXmlNamespace> predicate) {
         return getNamespaceList().removeIf(predicate);
     }
     public Iterator<ResXmlNamespace> getVisibleNamespaces() {

--- a/src/main/java/com/reandroid/arsc/chunk/xml/ResXmlNodeTree.java
+++ b/src/main/java/com/reandroid/arsc/chunk/xml/ResXmlNodeTree.java
@@ -14,7 +14,7 @@ import java.util.AbstractList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Predicate;
+
 
 public abstract class ResXmlNodeTree extends ResXmlNode implements NodeTree<ResXmlNode> {
 
@@ -45,7 +45,7 @@ public abstract class ResXmlNodeTree extends ResXmlNode implements NodeTree<ResX
     public<T extends ResXmlNode> Iterator<T> recursive(Class<T> instance) {
         return InstanceIterator.of(recursive(), instance);
     }
-    public<T extends ResXmlNode> Iterator<T> recursive(Class<T> instance, Predicate<? super T> predicate) {
+    public<T extends ResXmlNode> Iterator<T> recursive(Class<T> instance, org.apache.commons.collections4.Predicate<? super T> predicate) {
         return InstanceIterator.of(recursive(), instance, predicate);
     }
     public Iterator<ResXmlNode> recursive() {
@@ -101,10 +101,10 @@ public abstract class ResXmlNodeTree extends ResXmlNode implements NodeTree<ResX
         return getNodeList().remove(i);
     }
     @Override
-    public boolean removeIf(Predicate<? super ResXmlNode> predicate) {
+    public boolean removeIf(org.apache.commons.collections4.Predicate<? super ResXmlNode> predicate) {
         return getNodeList().removeIf(predicate);
     }
-    public int countIf(Predicate<? super ResXmlNode> predicate) {
+    public int countIf(org.apache.commons.collections4.Predicate<? super ResXmlNode> predicate) {
         return getNodeList().countIf(predicate);
     }
     @Override

--- a/src/main/java/com/reandroid/arsc/coder/ThreeByteCharsetDecoder.java
+++ b/src/main/java/com/reandroid/arsc/coder/ThreeByteCharsetDecoder.java
@@ -25,7 +25,7 @@ import java.nio.charset.StandardCharsets;
 public class ThreeByteCharsetDecoder extends CharsetDecoder {
     public static final ThreeByteCharsetDecoder INSTANCE = new ThreeByteCharsetDecoder();
     public ThreeByteCharsetDecoder() {
-        super(StandardCharsets.UTF_8, 1.0F, 1.0F);
+        super(com.reandroid.utils.StringsUtil.UTF_8, 1.0F, 1.0F);
     }
     @Override
     protected CoderResult decodeLoop(ByteBuffer src, CharBuffer dst) {
@@ -150,7 +150,7 @@ public class ThreeByteCharsetDecoder extends CharsetDecoder {
         return xFlow(src, mark, 0);
     }
 
-    private static void updatePositions(Buffer src, int sourcePosition, Buffer dst, int dstPosition) {
+    private static void updatePositions(ByteBuffer src, int sourcePosition, CharBuffer dst, int dstPosition) {
         src.position(sourcePosition - src.arrayOffset());
         dst.position(dstPosition - dst.arrayOffset());
     }
@@ -211,7 +211,7 @@ public class ThreeByteCharsetDecoder extends CharsetDecoder {
         src.position(mark);
         return CoderResult.malformedForLength(1);
     }
-    private static CoderResult xFlow(Buffer src, int sourcePosition, int sourceLimit, Buffer dst, int dstPosition, int numBytes) {
+    private static CoderResult xFlow(ByteBuffer src, int sourcePosition, int sourceLimit, CharBuffer dst, int dstPosition, int numBytes) {
         updatePositions(src, sourcePosition, dst, dstPosition);
         return numBytes != 0 && sourceLimit - sourcePosition >= numBytes ? CoderResult.OVERFLOW : CoderResult.UNDERFLOW;
     }

--- a/src/main/java/com/reandroid/arsc/coder/xml/AaptXmlStringDecoder.java
+++ b/src/main/java/com/reandroid/arsc/coder/xml/AaptXmlStringDecoder.java
@@ -16,6 +16,7 @@
 package com.reandroid.arsc.coder.xml;
 
 import com.reandroid.arsc.item.StringItem;
+import com.reandroid.utils.StringsUtil;
 import com.reandroid.xml.StyleDocument;
 import com.reandroid.xml.StyleText;
 import com.reandroid.xml.XMLUtil;
@@ -57,7 +58,7 @@ public class AaptXmlStringDecoder implements XmlStringDecoder {
 
     // Copied from github.com/iBotPeaches/Apktool
     public static String escapeXmlValue(String str) {
-        if (str == null || str.isEmpty()) {
+        if (StringsUtil.isEmpty(str)) {
             return str;
         }
 

--- a/src/main/java/com/reandroid/arsc/coder/xml/XmlCoder.java
+++ b/src/main/java/com/reandroid/arsc/coder/xml/XmlCoder.java
@@ -37,7 +37,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.function.Predicate;
+
 
 public class XmlCoder {
 
@@ -102,7 +102,7 @@ public class XmlCoder {
 
         public void decodeTable(File resourcesDir,
                                 TableBlock tableBlock,
-                                Predicate<Entry> decodedEntries) throws IOException {
+                                org.apache.commons.collections4.Predicate<Entry> decodedEntries) throws IOException {
             logMessage("Resource table ...");
             ValuesDirectorySerializer directorySerializer =
                     new ValuesDirectorySerializer(resourcesDir);
@@ -111,14 +111,14 @@ public class XmlCoder {
         }
         public void decodeTable(ValuesSerializerFactory serializerFactory,
                                   TableBlock tableBlock,
-                                  Predicate<Entry> decodedEntries) throws IOException {
+                                  org.apache.commons.collections4.Predicate<Entry> decodedEntries) throws IOException {
             for (PackageBlock packageBlock : tableBlock.listPackages()){
                 decodePackage(serializerFactory, packageBlock, decodedEntries);
             }
         }
         public void decodePackage(ValuesSerializerFactory serializerFactory,
                            PackageBlock packageBlock,
-                           Predicate<Entry> decodedEntries) throws IOException {
+                           org.apache.commons.collections4.Predicate<Entry> decodedEntries) throws IOException {
 
             packageBlock.sortTypes();
 
@@ -142,14 +142,14 @@ public class XmlCoder {
         public int decode(XmlSerializer serializer,
                            SpecTypePair specTypePair,
                            ResConfig resConfig,
-                           Predicate<Entry> decodedEntries) throws IOException {
+                           org.apache.commons.collections4.Predicate<Entry> decodedEntries) throws IOException {
             Iterator<ResourceEntry> resources = specTypePair.getResources();
             return decode(serializer, resources, resConfig, decodedEntries);
         }
         public int decode(XmlSerializer serializer,
                            Iterator<ResourceEntry> resources,
                            ResConfig resConfig,
-                           Predicate<Entry> decodedEntries) throws IOException {
+                           org.apache.commons.collections4.Predicate<Entry> decodedEntries) throws IOException {
             int entriesCount = 0;
             while (resources.hasNext()){
                 ResourceEntry resourceEntry = resources.next();
@@ -166,9 +166,9 @@ public class XmlCoder {
         public boolean decode(XmlSerializer serializer,
                            ResourceEntry resourceEntry,
                            ResConfig resConfig,
-                           Predicate<Entry> decodedEntries) throws IOException {
+                           org.apache.commons.collections4.Predicate<Entry> decodedEntries) throws IOException {
             Entry entry = resourceEntry.get(resConfig);
-            if(entry == null || decodedEntries.test(entry)){
+            if(entry == null || decodedEntries.evaluate(entry)){
                 return false;
             }
             if(entry.isComplex()){

--- a/src/main/java/com/reandroid/arsc/container/BlockList.java
+++ b/src/main/java/com/reandroid/arsc/container/BlockList.java
@@ -28,7 +28,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Predicate;
+
 
 public class BlockList<T extends Block> extends Block implements BlockRefresh, Swappable {
     private ArrayCollection<T> mItems;
@@ -144,7 +144,7 @@ public class BlockList<T extends Block> extends Block implements BlockRefresh, S
     public Iterator<T> iterator(int start, int length){
         return mItems.iterator(start, length);
     }
-    public Iterator<T> iterator(Predicate<? super T> filter){
+    public Iterator<T> iterator(org.apache.commons.collections4.Predicate<? super T> filter){
         return mItems.iterator(filter);
     }
     public<T1> Iterator<T1> iterator(Class<T1> instance){
@@ -158,13 +158,13 @@ public class BlockList<T extends Block> extends Block implements BlockRefresh, S
         return mItems.lastIndexOf(item);
     }
 
-    public int countIf(Predicate<? super T> predicate){
+    public int countIf(org.apache.commons.collections4.Predicate<? super T> predicate){
         return mItems.count(predicate);
     }
-    public int countFromLast(Predicate<? super T> predicate){
+    public int countFromLast(org.apache.commons.collections4.Predicate<? super T> predicate){
         return mItems.countFromLast(predicate);
     }
-    public ArrayCollection<T> subListIf(Predicate<? super T> predicate) {
+    public ArrayCollection<T> subListIf(org.apache.commons.collections4.Predicate<? super T> predicate) {
         return mItems.subListIf(predicate);
     }
     public void clearChildes(){
@@ -265,7 +265,7 @@ public class BlockList<T extends Block> extends Block implements BlockRefresh, S
         onRemoveRequestCompleted(lock);
         return true;
     }
-    public boolean removeIf(Predicate<? super T> filter){
+    public boolean removeIf(org.apache.commons.collections4.Predicate<? super T> filter){
         Object lock = onRemoveRequestStarted();
         boolean removed = mItems.removeIf(filter);
         if(removed) {
@@ -511,14 +511,14 @@ public class BlockList<T extends Block> extends Block implements BlockRefresh, S
     public <T1> T1[] toArray(T1[] ts) {
         return mItems.toArray(ts);
     }
-    public T[] toArrayIf(Predicate<? super T> predicate, BlockArrayCreator<? extends T> creator) {
+    public T[] toArrayIf(org.apache.commons.collections4.Predicate<? super T> predicate, BlockArrayCreator<? extends T> creator) {
         int length = countIf(predicate);
         int size = size();
         T[] results = creator.newArrayInstance(length);
         int j = 0;
         for (int i = 0; i < size; i++) {
             T item = get(i);
-            if (predicate.test(item)) {
+            if (predicate.evaluate(item)) {
                 results[j] = item;
                 j ++;
             }

--- a/src/main/java/com/reandroid/arsc/container/CountedBlockList.java
+++ b/src/main/java/com/reandroid/arsc/container/CountedBlockList.java
@@ -23,7 +23,7 @@ import com.reandroid.arsc.item.IntegerReference;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.function.Predicate;
+
 
 public class CountedBlockList<T extends Block> extends BlockList<T> implements DirectStreamReader {
 
@@ -69,7 +69,7 @@ public class CountedBlockList<T extends Block> extends BlockList<T> implements D
     public T[] toArray() {
         return super.toArray(getCreator().newArrayInstance(size()));
     }
-    public T[] toArrayIf(Predicate<? super T> predicate) {
+    public T[] toArrayIf(org.apache.commons.collections4.Predicate<? super T> predicate) {
         return toArrayIf(predicate, getCreator());
     }
 }

--- a/src/main/java/com/reandroid/arsc/container/SpecTypePair.java
+++ b/src/main/java/com/reandroid/arsc/container/SpecTypePair.java
@@ -43,7 +43,7 @@ import org.xmlpull.v1.XmlSerializer;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.function.Predicate;
+
 
 public class SpecTypePair extends BlockContainer<Block>
         implements Iterable<TypeBlock>, JSONConvert<JSONObject>, Comparable<SpecTypePair>{
@@ -159,7 +159,7 @@ public class SpecTypePair extends BlockContainer<Block>
     public Iterator<TypeBlock> getTypeBlocks(){
         return getTypeBlockArray().iterator();
     }
-    public Iterator<TypeBlock> getTypeBlocks(Predicate<TypeBlock> filter){
+    public Iterator<TypeBlock> getTypeBlocks(org.apache.commons.collections4.Predicate<TypeBlock> filter){
         return getTypeBlockArray().iterator(filter);
     }
     public Iterator<TypeBlock> getTypeBlocks(ResConfig resConfig){

--- a/src/main/java/com/reandroid/arsc/item/FixedLengthString.java
+++ b/src/main/java/com/reandroid/arsc/item/FixedLengthString.java
@@ -74,7 +74,7 @@ public class FixedLengthString  extends StringItem {
             return null;
         }
         int length = getEndNullPosition(bytes);
-        return new String(bytes,0, length, StandardCharsets.UTF_16LE);
+        return new String(bytes,0, length, com.reandroid.utils.StringsUtil.UTF_16LE);
     }
     private static int getEndNullPosition(byte[] bytes){
         int length = bytes.length;

--- a/src/main/java/com/reandroid/arsc/item/SpecString.java
+++ b/src/main/java/com/reandroid/arsc/item/SpecString.java
@@ -20,7 +20,7 @@ import com.reandroid.arsc.value.Entry;
 import com.reandroid.utils.CompareUtil;
 
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class SpecString extends StringItem {
     public SpecString(boolean utf8) {
@@ -35,30 +35,30 @@ public class SpecString extends StringItem {
         return 0;
     }
 
-    public Iterator<Entry> getEntries(Predicate<Entry> filter){
+    public Iterator<Entry> getEntries(org.apache.commons.collections4.Predicate<Entry> filter){
         return getUsers(Entry.class, filter);
     }
     public Iterator<Entry> getEntries(final int typeId){
-        return getUsers(Entry.class, new Predicate<Entry>() {
+        return getUsers(Entry.class, new org.apache.commons.collections4.Predicate<Entry>() {
             @Override
-            public boolean test(Entry item) {
+            public boolean evaluate(Entry item) {
                 return typeId == item.getTypeId();
             }
         });
     }
     public Iterator<Entry> getEntries(final String typeName){
-        return getUsers(Entry.class, new Predicate<Entry>() {
+        return getUsers(Entry.class, new org.apache.commons.collections4.Predicate<Entry>() {
             @Override
-            public boolean test(Entry item) {
+            public boolean evaluate(Entry item) {
                 return typeName == null
                         || typeName.equals(item.getTypeName());
             }
         });
     }
     public Iterator<Entry> getEntries(final Block parentContext){
-        return getUsers(Entry.class, new Predicate<Entry>() {
+        return getUsers(Entry.class, new org.apache.commons.collections4.Predicate<Entry>() {
             @Override
-            public boolean test(Entry item) {
+            public boolean evaluate(Entry item) {
                 return item.getParentInstance(parentContext.getClass())
                         == parentContext;
             }

--- a/src/main/java/com/reandroid/arsc/item/StringBlock.java
+++ b/src/main/java/com/reandroid/arsc/item/StringBlock.java
@@ -71,5 +71,5 @@ public abstract class StringBlock extends BlockItem implements StringReference {
         return get();
     }
 
-    public static final CharsetDecoder UTF8_DECODER = StandardCharsets.UTF_8.newDecoder();
+    public static final CharsetDecoder UTF8_DECODER = com.reandroid.utils.StringsUtil.UTF_8.newDecoder();
 }

--- a/src/main/java/com/reandroid/arsc/item/TableString.java
+++ b/src/main/java/com/reandroid/arsc/item/TableString.java
@@ -21,7 +21,7 @@ import org.xmlpull.v1.XmlSerializer;
 
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class TableString extends StringItem {
 
@@ -46,7 +46,7 @@ public class TableString extends StringItem {
             return item.isScalar();
         });
     }
-    public Iterator<Entry> getEntries(Predicate<Entry> tester) {
+    public Iterator<Entry> getEntries(org.apache.commons.collections4.Predicate<Entry> tester) {
         return super.getUsers(Entry.class, tester);
     }
 }

--- a/src/main/java/com/reandroid/arsc/model/FrameworkTable.java
+++ b/src/main/java/com/reandroid/arsc/model/FrameworkTable.java
@@ -29,6 +29,7 @@ import com.reandroid.arsc.pool.TableStringPool;
 import com.reandroid.arsc.value.Entry;
 import com.reandroid.arsc.value.ResConfig;
 import com.reandroid.common.FileChannelInputStream;
+import com.reandroid.utils.StringsUtil;
 import com.reandroid.utils.collection.ArrayCollection;
 
 import java.io.File;
@@ -97,7 +98,7 @@ public class FrameworkTable extends TableBlock {
             PackageBlock packageBlock = pickOne();
             if(packageBlock!=null){
                 String name = packageBlock.getName();
-                if(name!=null && !name.trim().isEmpty()){
+                if(!StringsUtil.isBlank(name)){
                     frameworkName = name;
                 }
             }

--- a/src/main/java/com/reandroid/arsc/model/ResourceEntry.java
+++ b/src/main/java/com/reandroid/arsc/model/ResourceEntry.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.function.Predicate;
+
 
 public class ResourceEntry implements Iterable<Entry>{
     private final int resourceId;
@@ -299,7 +299,7 @@ public class ResourceEntry implements Iterable<Entry>{
     public Iterator<Entry> iterator(boolean skipNull){
         return getPackageBlock().getEntries(getResourceId(), skipNull);
     }
-    public Iterator<Entry> iterator(Predicate<? super Entry> filter) {
+    public Iterator<Entry> iterator(org.apache.commons.collections4.Predicate<? super Entry> filter) {
         return new FilterIterator<>(getPackageBlock().getEntries(getResourceId()), filter);
     }
     public Iterator<ResConfig> getConfigs(){

--- a/src/main/java/com/reandroid/arsc/pool/StringPool.java
+++ b/src/main/java/com/reandroid/arsc/pool/StringPool.java
@@ -42,7 +42,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Predicate;
+
 
 public abstract class StringPool<T extends StringItem> extends Chunk<StringPoolHeader>
         implements BlockLoad, Iterable<T>, JSONConvert<JSONArray> {
@@ -167,7 +167,7 @@ public abstract class StringPool<T extends StringItem> extends Chunk<StringPoolH
         return ComputeIterator.of(iterator(), T::getXml);
     }
     public void addStrings(Collection<String> stringList){
-        if(stringList == null || stringList.size() == 0){
+        if(stringList == null || stringList.isEmpty()){
             return;
         }
         for(String str : stringList) {
@@ -197,7 +197,7 @@ public abstract class StringPool<T extends StringItem> extends Chunk<StringPoolH
     public List<T> listUnusedStrings(){
         return getStringsArray().subListIf(getUnusedStringsFilter());
     }
-    private Predicate<T> getUnusedStringsFilter() {
+    private org.apache.commons.collections4.Predicate<T> getUnusedStringsFilter() {
         return item -> !item.hasReference();
     }
     public StyleArray getStyleArray(){
@@ -245,7 +245,7 @@ public abstract class StringPool<T extends StringItem> extends Chunk<StringPoolH
         ensureStringLinkUnlockedInternal();
         return poolMap.getAll(str);
     }
-    public final T get(String str, Predicate<? super T> predicate){
+    public final T get(String str, org.apache.commons.collections4.Predicate<? super T> predicate){
         ensureStringLinkUnlockedInternal();
         return poolMap.get(str, predicate);
     }

--- a/src/main/java/com/reandroid/arsc/refactor/ResourceBuilder.java
+++ b/src/main/java/com/reandroid/arsc/refactor/ResourceBuilder.java
@@ -32,10 +32,11 @@ import com.reandroid.arsc.value.Entry;
 import com.reandroid.arsc.value.ResConfig;
 import com.reandroid.utils.CompareUtil;
 import com.reandroid.utils.collection.ArrayCollection;
+import com.reandroid.utils.collection.CollectionUtil;
 import com.reandroid.utils.collection.FilterIterator;
 
 import java.util.*;
-import java.util.function.Predicate;
+
 
 public class ResourceBuilder {
 
@@ -182,7 +183,7 @@ public class ResourceBuilder {
     }
     private void mergePackage(PackageBlock sourcePackage, PackageBlock resultPackage) {
         ResourceMergeOption mergeOption = this.getMergeOption();
-        Predicate<? super ResourceEntry> keepEntries = mergeOption.getKeepEntries();
+        org.apache.commons.collections4.Predicate<? super ResourceEntry> keepEntries = mergeOption.getKeepEntries();
         Iterator<ResourceEntry> iterator = FilterIterator.of(sourcePackage.getResources(), keepEntries);
         while (iterator.hasNext()){
             ResourceEntry sourceEntry = iterator.next();
@@ -224,7 +225,7 @@ public class ResourceBuilder {
         initializeEntries(sourcePackage, resultPackage);
     }
     private void initializeTypeString(PackageBlock sourcePackage, PackageBlock resultPackage) {
-        Predicate<? super ResourceEntry> keepEntries = getMergeOption().getKeepEntries();
+        org.apache.commons.collections4.Predicate<? super ResourceEntry> keepEntries = getMergeOption().getKeepEntries();
         TypeStringPool sourcePool = sourcePackage.getTypeStringPool();
         Set<String> typeSet = new HashSet<>(sourcePool.size());
         for(TypeString typeString : sourcePool) {
@@ -236,7 +237,7 @@ public class ResourceBuilder {
             }
         }
         List<String> typeList = new ArrayCollection<>(typeSet);
-        typeList.sort(CompareUtil.getComparableComparator());
+        java.util.Collections.sort(typeList, CompareUtil.getComparableComparator());
         resultPackage.getTypeStringPool().addStrings(typeList);
     }
     private void initializeSpecString(PackageBlock sourcePackage, PackageBlock resultPackage) {
@@ -250,12 +251,12 @@ public class ResourceBuilder {
         }
     }
     private void initializeEntries(String typeName, PackageBlock sourcePackage, PackageBlock resultPackage) {
-        Predicate<? super ResourceEntry> keepEntries = getMergeOption().getKeepEntries();
+        org.apache.commons.collections4.Predicate<? super ResourceEntry> keepEntries = getMergeOption().getKeepEntries();
         ArrayCollection<ResourceEntry> sourceEntryList = new ArrayCollection<>();
         Iterator<ResourceEntry> iterator = FilterIterator.of(
                 sourcePackage.getResources(typeName),
                 resourceEntry -> resourceEntry.isDefined() &&
-                        keepEntries.test(resourceEntry));
+                        keepEntries.evaluate(resourceEntry));
         sourceEntryList.addAll(iterator);
 
         sourceEntryList.sort(this::compareEntryNames);

--- a/src/main/java/com/reandroid/arsc/refactor/ResourceMergeOption.java
+++ b/src/main/java/com/reandroid/arsc/refactor/ResourceMergeOption.java
@@ -36,13 +36,13 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.function.Predicate;
+
 
 public class ResourceMergeOption {
 
-    private Predicate<? super ResourceEntry> keepEntries;
-    private Predicate<? super ResourceName> keepResourceNameFilter;
-    private Predicate<? super ResConfig> keepConfigs;
+    private org.apache.commons.collections4.Predicate<? super ResourceEntry> keepEntries;
+    private org.apache.commons.collections4.Predicate<? super ResourceName> keepResourceNameFilter;
+    private org.apache.commons.collections4.Predicate<? super ResConfig> keepConfigs;
 
     private final Set<ResourceName> keepResourceNameList;
 
@@ -50,69 +50,69 @@ public class ResourceMergeOption {
         this.keepResourceNameList = new HashSet<>();
     }
 
-    public Predicate<? super Entry> getKeepEntryConfigs() {
-        Predicate<? super ResConfig> keepConfigs = this.getKeepConfigs();
-        return (Predicate<Entry>) entry -> keepConfigs.test(entry.getResConfig());
+    public org.apache.commons.collections4.Predicate<? super Entry> getKeepEntryConfigs() {
+        org.apache.commons.collections4.Predicate<? super ResConfig> keepConfigs = this.getKeepConfigs();
+        return (org.apache.commons.collections4.Predicate<Entry>) entry -> keepConfigs.evaluate(entry.getResConfig());
     }
-    public Predicate<? super ResConfig> getKeepConfigs() {
-        Predicate<? super ResConfig> keepConfigs = this.keepConfigs;
+    public org.apache.commons.collections4.Predicate<? super ResConfig> getKeepConfigs() {
+        org.apache.commons.collections4.Predicate<? super ResConfig> keepConfigs = this.keepConfigs;
         if(keepConfigs == null) {
             keepConfigs = CollectionUtil.getAcceptAll();
         }
         return keepConfigs;
     }
-    public void setKeepConfigs(Predicate<? super ResConfig> keepConfigs) {
+    public void setKeepConfigs(org.apache.commons.collections4.Predicate<? super ResConfig> keepConfigs) {
         this.keepConfigs = keepConfigs;
     }
-    public Predicate<? super ResourceEntry> getKeepEntries() {
-        Predicate<? super ResourceEntry> keepEntries = this.getKeepEntriesInternal();
-        Predicate<? super ResourceName> keepResourceNames = this.getKeepResourceName();
-        Predicate<? super ResourceEntry> result = keepEntries;
+    public org.apache.commons.collections4.Predicate<? super ResourceEntry> getKeepEntries() {
+        org.apache.commons.collections4.Predicate<? super ResourceEntry> keepEntries = this.getKeepEntriesInternal();
+        org.apache.commons.collections4.Predicate<? super ResourceName> keepResourceNames = this.getKeepResourceName();
+        org.apache.commons.collections4.Predicate<? super ResourceEntry> result = keepEntries;
         if(keepResourceNames != null) {
-            result = (Predicate<ResourceEntry>) resourceEntry -> {
-                if(keepEntries.test(resourceEntry)) {
+            result = (org.apache.commons.collections4.Predicate<ResourceEntry>) resourceEntry -> {
+                if(keepEntries.evaluate(resourceEntry)) {
                     return true;
                 }
                 ResourceName resourceName = resourceEntry.toResourceName();
                 if(resourceName != null) {
-                    return keepResourceNames.test(resourceName);
+                    return keepResourceNames.evaluate(resourceName);
                 }
                 return false;
             };
         }
         return result;
     }
-    private Predicate<? super ResourceEntry> getKeepEntriesInternal() {
-        Predicate<? super ResourceEntry> keepEntries = this.keepEntries;
+    private org.apache.commons.collections4.Predicate<? super ResourceEntry> getKeepEntriesInternal() {
+        org.apache.commons.collections4.Predicate<? super ResourceEntry> keepEntries = this.keepEntries;
         if(keepEntries == null) {
             keepEntries = resourceEntry -> !resourceEntry.isEmpty();
             this.keepEntries = keepEntries;
         }
         return CollectionUtil.orFilter(keepEntries, getKeepStyleEntries());
     }
-    private Predicate<? super ResourceEntry> getKeepStyleEntries() {
-        return (Predicate<ResourceEntry>) resourceEntry ->
+    private org.apache.commons.collections4.Predicate<? super ResourceEntry> getKeepStyleEntries() {
+        return (org.apache.commons.collections4.Predicate<ResourceEntry>) resourceEntry ->
                 TypeString.isTypeStyle(resourceEntry.getType()) &&
                 resourceEntry.getName().indexOf('.') > 0;
     }
-    public void setKeepEntries(Predicate<? super ResourceEntry> keepEntries) {
+    public void setKeepEntries(org.apache.commons.collections4.Predicate<? super ResourceEntry> keepEntries) {
         this.keepEntries = keepEntries;
     }
 
-    public Predicate<? super ResourceName> getKeepResourceName() {
+    public org.apache.commons.collections4.Predicate<? super ResourceName> getKeepResourceName() {
         return CollectionUtil.orFilter(getKeepResourceNameFilter(),
                 getKeepResourceNameListFilter());
     }
-    public void setKeepResourceNameFilter(Predicate<? super ResourceName> keepResourceNameFilter) {
+    public void setKeepResourceNameFilter(org.apache.commons.collections4.Predicate<? super ResourceName> keepResourceNameFilter) {
         this.keepResourceNameFilter = keepResourceNameFilter;
     }
-    private Predicate<? super ResourceName> getKeepResourceNameFilter() {
+    private org.apache.commons.collections4.Predicate<? super ResourceName> getKeepResourceNameFilter() {
         return keepResourceNameFilter;
     }
-    private Predicate<? super ResourceName> getKeepResourceNameListFilter() {
+    private org.apache.commons.collections4.Predicate<? super ResourceName> getKeepResourceNameListFilter() {
         Set<ResourceName> keepResourceNameList = this.keepResourceNameList;
         if(!keepResourceNameList.isEmpty()) {
-            return (Predicate<ResourceName>) keepResourceNameList::contains;
+            return (org.apache.commons.collections4.Predicate<ResourceName>) keepResourceNameList::contains;
         }
         return null;
     }

--- a/src/main/java/com/reandroid/common/ReferenceResolver.java
+++ b/src/main/java/com/reandroid/common/ReferenceResolver.java
@@ -22,9 +22,10 @@ import com.reandroid.arsc.value.ResConfig;
 import com.reandroid.arsc.value.ResValue;
 import com.reandroid.arsc.value.ValueType;
 import com.reandroid.utils.collection.ArrayCollection;
+import com.reandroid.utils.collection.CollectionUtil;
 
 import java.util.*;
-import java.util.function.Predicate;
+
 
 public class ReferenceResolver{
     private final TableBlock entryStore;
@@ -40,7 +41,7 @@ public class ReferenceResolver{
     public Entry resolve(int referenceId){
         return resolve(referenceId, null);
     }
-    public synchronized Entry resolve(int referenceId, Predicate<Entry> filter){
+    public synchronized Entry resolve(int referenceId, org.apache.commons.collections4.Predicate<Entry> filter){
         resolveReference(referenceId, filter);
         List<Entry> results = new ArrayCollection<>(this.results);
         reset();
@@ -53,19 +54,19 @@ public class ReferenceResolver{
     public List<Entry> resolveWithConfig(int referenceId, ResConfig resConfig){
         ConfigFilter configFilter = new ConfigFilter(resConfig);
         List<Entry> results = resolveAll(referenceId, configFilter);
-        results.sort(configFilter);
+        java.util.Collections.sort(results, configFilter);
         return results;
     }
     public List<Entry> resolveAll(int referenceId){
-        return resolveAll(referenceId, (Predicate<Entry>)null);
+        return resolveAll(referenceId, null);
     }
-    public synchronized List<Entry> resolveAll(int referenceId, Predicate<Entry> filter){
+    public synchronized List<Entry> resolveAll(int referenceId, org.apache.commons.collections4.Predicate<Entry> filter){
         resolveReference(referenceId, filter);
         List<Entry> results = new ArrayCollection<>(this.results);
         reset();
         return results;
     }
-    private void resolveReference(int referenceId, Predicate<Entry> filter){
+    private void resolveReference(int referenceId, org.apache.commons.collections4.Predicate<Entry> filter){
         if(referenceId == 0 || isFinished() || this.resolvedIds.contains(referenceId)){
             return;
         }
@@ -99,8 +100,8 @@ public class ReferenceResolver{
     private boolean isFinished(){
         return this.limit >= this.results.size();
     }
-    private void addResult(Predicate<Entry> filter, Entry entry){
-        if(filter == null || filter.test(entry)){
+    private void addResult(org.apache.commons.collections4.Predicate<Entry> filter, Entry entry){
+        if(filter == null || filter.evaluate(entry)){
             this.results.add(entry);
         }
     }
@@ -117,13 +118,13 @@ public class ReferenceResolver{
         return results;
     }
 
-    public static class ConfigFilter implements Predicate<Entry>, Comparator<Entry>{
+    public static class ConfigFilter implements org.apache.commons.collections4.Predicate<Entry>, Comparator<Entry>{
         private final ResConfig config;
         public ConfigFilter(ResConfig config){
             this.config = config;
         }
         @Override
-        public boolean test(Entry entry) {
+        public boolean evaluate(Entry entry) {
             ResConfig resConfig = entry.getResConfig();
             if(resConfig == null){
                 return false;

--- a/src/main/java/com/reandroid/dex/common/AccessFlag.java
+++ b/src/main/java/com/reandroid/dex/common/AccessFlag.java
@@ -24,7 +24,7 @@ import java.lang.annotation.ElementType;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Predicate;
+
 
 public class AccessFlag extends Modifier{
 
@@ -168,7 +168,7 @@ public class AccessFlag extends Modifier{
     public static Iterator<AccessFlag> getValues(){
         return getValues(null);
     }
-    public static Iterator<AccessFlag> getValues(Predicate<AccessFlag> filter){
+    public static Iterator<AccessFlag> getValues(org.apache.commons.collections4.Predicate<AccessFlag> filter){
         return new ArrayIterator<>(VALUES, filter);
     }
     public static AccessFlag[] parse(SmaliReader reader){

--- a/src/main/java/com/reandroid/dex/common/DexUtils.java
+++ b/src/main/java/com/reandroid/dex/common/DexUtils.java
@@ -26,7 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
-import java.util.function.Function;
+import org.apache.commons.collections4.Transformer;
 
 public class DexUtils {
 
@@ -50,11 +50,11 @@ public class DexUtils {
     public static<T> Comparator<T> getDexPathComparator(){
         return DexUtils::compareDex;
     }
-    public static<T, E> Comparator<T> getDexPathComparator(Function<T, E> function){
+    public static<T, E> Comparator<T> getDexPathComparator(Transformer<T, E> function){
         return (dex1, dex2) -> compareDex(function, dex1, dex2);
     }
-    public static<T, E> int compareDex(Function<T, E> function, T dexPath1, T dexPath2){
-        return compareDex(function.apply(dexPath1), function.apply(dexPath2));
+    public static<T, E> int compareDex(Transformer<T, E> function, T dexPath1, T dexPath2){
+        return compareDex(function.transformer(dexPath1), function.transformer(dexPath2));
     }
     public static int compareDex(Object dexPath1, Object dexPath2){
         if(dexPath1 == dexPath2){
@@ -194,7 +194,7 @@ public class DexUtils {
                 }
             }
             escapeChar(appendable, c);
-            if(!unicodeDetected && c != '…' && c > 0xff) {
+            if(!unicodeDetected && c != '\u2026' && c > 0xff) {
                 unicodeDetected = true;
             }
         }

--- a/src/main/java/com/reandroid/dex/common/HiddenApiFlag.java
+++ b/src/main/java/com/reandroid/dex/common/HiddenApiFlag.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
+
 
 public class HiddenApiFlag extends Modifier implements SmaliFormat {
 
@@ -124,7 +124,7 @@ public class HiddenApiFlag extends Modifier implements SmaliFormat {
     public static Iterator<HiddenApiFlag> getValues(){
         return getValues(null);
     }
-    public static Iterator<HiddenApiFlag> getValues(Predicate<HiddenApiFlag> filter){
+    public static Iterator<HiddenApiFlag> getValues(org.apache.commons.collections4.Predicate<HiddenApiFlag> filter){
         return new ArrayIterator<>(VALUES, filter);
     }
     public static HiddenApiFlag restrictionOf(int value) {

--- a/src/main/java/com/reandroid/dex/dalvik/DalvikMemberClass.java
+++ b/src/main/java/com/reandroid/dex/dalvik/DalvikMemberClass.java
@@ -25,7 +25,7 @@ import com.reandroid.utils.StringsUtil;
 import com.reandroid.utils.collection.CollectionUtil;
 
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class DalvikMemberClass extends DalvikAnnotation {
 
@@ -52,7 +52,7 @@ public class DalvikMemberClass extends DalvikAnnotation {
                 .add(typeKey);
         setArray(array);
     }
-    public void removeIf(Predicate<? super TypeKey> predicate) {
+    public void removeIf(org.apache.commons.collections4.Predicate<? super TypeKey> predicate) {
         ArrayValueKey array = getArray()
                 .removeIf(ObjectsUtil.cast(predicate));
         setArray(array);

--- a/src/main/java/com/reandroid/dex/data/AnnotationItem.java
+++ b/src/main/java/com/reandroid/dex/data/AnnotationItem.java
@@ -44,7 +44,7 @@ import com.reandroid.utils.collection.IterableIterator;
 
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class AnnotationItem extends DataItem
         implements Comparable<AnnotationItem>, Iterable<AnnotationElement>,
@@ -87,7 +87,7 @@ public class AnnotationItem extends DataItem
     public SectionType<AnnotationItem> getSectionType() {
         return SectionType.ANNOTATION_ITEM;
     }
-    public boolean removeIf(Predicate<AnnotationElement> filter){
+    public boolean removeIf(org.apache.commons.collections4.Predicate<AnnotationElement> filter){
         return annotationElements.removeIf(filter);
     }
     public void remove(AnnotationElement element){
@@ -426,9 +426,9 @@ public class AnnotationItem extends DataItem
             return false;
         }
         @Override
-        public boolean removeAnnotationIf(Predicate<? super AnnotationItemKey> predicate) {
+        public boolean removeAnnotationIf(org.apache.commons.collections4.Predicate<? super AnnotationItemKey> predicate) {
             AnnotationItemKey itemKey = getItemKey();
-            if (itemKey != null && predicate.test(itemKey)) {
+            if (itemKey != null && predicate.evaluate(itemKey)) {
                 clearAnnotations();
                 return true;
             }

--- a/src/main/java/com/reandroid/dex/data/AnnotationSet.java
+++ b/src/main/java/com/reandroid/dex/data/AnnotationSet.java
@@ -36,7 +36,7 @@ import com.reandroid.utils.collection.IterableIterator;
 
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class AnnotationSet extends IntegerDataItemList<AnnotationItem>
         implements KeyReference, SmaliFormat, PositionAlignedItem,
@@ -52,8 +52,8 @@ public class AnnotationSet extends IntegerDataItemList<AnnotationItem>
     public boolean remove(AnnotationItemKey itemKey) {
         return removeIf(item -> ObjectsUtil.equals(itemKey, item.getKey()));
     }
-    public boolean removeAnnotationIf(Predicate<? super AnnotationItemKey> predicate) {
-        return removeIf(item -> predicate.test(item.getKey()));
+    public boolean removeAnnotationIf(org.apache.commons.collections4.Predicate<? super AnnotationItemKey> predicate) {
+        return removeIf(item -> predicate.evaluate(item.getKey()));
     }
     @Override
     public boolean isBlank() {

--- a/src/main/java/com/reandroid/dex/data/DirectoryMap.java
+++ b/src/main/java/com/reandroid/dex/data/DirectoryMap.java
@@ -15,7 +15,6 @@
  */
 package com.reandroid.dex.data;
 
-import com.reandroid.arsc.base.Block;
 import com.reandroid.arsc.base.Creator;
 import com.reandroid.arsc.container.CountedBlockList;
 import com.reandroid.arsc.item.IntegerReference;
@@ -25,7 +24,7 @@ import com.reandroid.utils.collection.ComputeIterator;
 import com.reandroid.utils.collection.FilterIterator;
 
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class DirectoryMap<DEFINITION extends DefIndex, VALUE extends DataItem>
         extends CountedBlockList<DirectoryEntry<DEFINITION, VALUE>>
@@ -81,8 +80,8 @@ public class DirectoryMap<DEFINITION extends DefIndex, VALUE extends DataItem>
     public void remove(DEFINITION definition) {
         super.removeIf(entry -> entry.equalsDefIndex(definition));
     }
-    public void remove(DEFINITION definition, Predicate<VALUE> filter) {
-        super.removeIf(entry -> entry.equalsDefIndex(definition) && filter.test(entry.getValue()));
+    public void remove(DEFINITION definition, org.apache.commons.collections4.Predicate<VALUE> filter) {
+        super.removeIf(entry -> entry.equalsDefIndex(definition) && filter.evaluate(entry.getValue()));
     }
     public void link(DEFINITION definition){
         for(DirectoryEntry<DEFINITION, VALUE> entry : this){

--- a/src/main/java/com/reandroid/dex/data/EncodedArray.java
+++ b/src/main/java/com/reandroid/dex/data/EncodedArray.java
@@ -35,7 +35,7 @@ import com.reandroid.utils.collection.IterableIterator;
 
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class EncodedArray extends DataItem implements KeyReference, Iterable<DexValueBlock<?>> {
 
@@ -117,7 +117,7 @@ public class EncodedArray extends DataItem implements KeyReference, Iterable<Dex
     public boolean remove(DexValueBlock<?> value){
         return getValueList().remove(value);
     }
-    public boolean removeIf(Predicate<? super DexValueBlock<?>> filter){
+    public boolean removeIf(org.apache.commons.collections4.Predicate<? super DexValueBlock<?>> filter){
         return getValueList().removeIf(filter);
     }
     public void set(int i, DexValueBlock<?> value){
@@ -164,7 +164,7 @@ public class EncodedArray extends DataItem implements KeyReference, Iterable<Dex
     public<T1 extends DexValueBlock<?>> Iterator<T1> iterator(Class<T1> instance){
         return InstanceIterator.of(iterator(), instance);
     }
-    public<T1 extends DexValueBlock<?>> Iterator<T1> iterator(Class<T1> instance, Predicate<? super T1> filter){
+    public<T1 extends DexValueBlock<?>> Iterator<T1> iterator(Class<T1> instance, org.apache.commons.collections4.Predicate<? super T1> filter){
         return InstanceIterator.of(iterator(), instance, filter);
     }
     public Iterator<DexValueBlock<?>> iterator(int start, int length) {

--- a/src/main/java/com/reandroid/dex/data/InstructionList.java
+++ b/src/main/java/com/reandroid/dex/data/InstructionList.java
@@ -41,7 +41,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Predicate;
+
 
 public class InstructionList extends FixedBlockContainer implements
         Iterable<Ins>, SmaliFormat {
@@ -160,7 +160,7 @@ public class InstructionList extends FixedBlockContainer implements
             return registerValue < count && isFreeRegister(registerValue, startIndex);
         });
         List<Register> list = CollectionUtil.toUniqueList(iterator);
-        list.sort(CompareUtil.getComparableComparator());
+        java.util.Collections.sort(list, CompareUtil.getComparableComparator());
         return list;
     }
     public boolean isFreeRegister(int registerValue, int startIndex){
@@ -191,12 +191,12 @@ public class InstructionList extends FixedBlockContainer implements
         return iterator(opcode, null);
     }
     @SuppressWarnings("unchecked")
-    public<T1 extends Ins> Iterator<T1> iterator(Opcode<T1> opcode, Predicate<? super T1> filter){
+    public<T1 extends Ins> Iterator<T1> iterator(Opcode<T1> opcode, org.apache.commons.collections4.Predicate<? super T1> filter){
         return ComputeIterator.of(iterator(), ins -> {
             T1 result = null;
             if(ins != null && ins.getOpcode() == opcode){
                 result = (T1) ins;
-                if(filter != null && !filter.test(result)){
+                if(filter != null && !filter.evaluate(result)){
                     result = null;
                 }
             }

--- a/src/main/java/com/reandroid/dex/data/IntegerDataItemList.java
+++ b/src/main/java/com/reandroid/dex/data/IntegerDataItemList.java
@@ -30,7 +30,7 @@ import com.reandroid.utils.collection.ComputeIterator;
 
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class IntegerDataItemList<T extends DataItem> extends DataItem implements Iterable<T> {
 
@@ -136,8 +136,8 @@ public class IntegerDataItemList<T extends DataItem> extends DataItem implements
     public void remove(T item) {
         removeIf(t -> t == item);
     }
-    public boolean removeIf(Predicate<? super T> filter) {
-        return referenceList.removeIf(reference -> filter.test(reference.getItem()));
+    public boolean removeIf(org.apache.commons.collections4.Predicate<? super T> filter) {
+        return referenceList.removeIf(reference -> filter.evaluate(reference.getItem()));
     }
     void removeNulls() {
         referenceList.removeIf(reference -> reference.getItem() == null);

--- a/src/main/java/com/reandroid/dex/data/ShortIdList.java
+++ b/src/main/java/com/reandroid/dex/data/ShortIdList.java
@@ -33,7 +33,7 @@ import com.reandroid.utils.collection.ComputeIterator;
 
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class ShortIdList<T extends IdItem> extends DataItem
         implements Comparable<ShortIdList<T>> {
@@ -137,8 +137,8 @@ public class ShortIdList<T extends IdItem> extends DataItem
     public boolean remove(T item) {
         return removeIf(t -> t == item);
     }
-    public boolean removeIf(Predicate<? super T> filter) {
-        return referenceList.removeIf(reference -> filter.test(reference.getItem()));
+    public boolean removeIf(org.apache.commons.collections4.Predicate<? super T> filter) {
+        return referenceList.removeIf(reference -> filter.evaluate(reference.getItem()));
     }
     void removeNulls() {
         removeIf(item -> item == null);

--- a/src/main/java/com/reandroid/dex/debug/DebugSequence.java
+++ b/src/main/java/com/reandroid/dex/debug/DebugSequence.java
@@ -28,7 +28,7 @@ import com.reandroid.utils.collection.*;
 
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class DebugSequence extends FixedDexContainer implements Iterable<DebugElement> {
 
@@ -94,10 +94,10 @@ public class DebugSequence extends FixedDexContainer implements Iterable<DebugEl
                 element -> (!(element instanceof DebugAdvance)));
     }
     public void fixDebugLineNumbers(){
-        Predicate<DebugElement> filter = new Predicate<DebugElement>() {
+        org.apache.commons.collections4.Predicate<DebugElement> filter = new org.apache.commons.collections4.Predicate<DebugElement>() {
             DebugElement previous = null;
             @Override
-            public boolean test(DebugElement element) {
+            public boolean evaluate(DebugElement element) {
                 if (element.getElementType() != DebugElementType.LINE_NUMBER) {
                     return false;
                 }
@@ -115,7 +115,7 @@ public class DebugSequence extends FixedDexContainer implements Iterable<DebugEl
         return removeAll(element -> element.getElementType() == DebugElementType.LINE_NUMBER &&
                        instructionList.getAtAddress(element.getTargetAddress()) == null);
     }
-    public boolean removeAll(Predicate<? super DebugElement> filter) {
+    public boolean removeAll(org.apache.commons.collections4.Predicate<? super DebugElement> filter) {
         boolean removedOnce = false;
         Iterator<DebugElement> iterator = FilterIterator.of(clonedIterator(), filter);
         while (iterator.hasNext()){

--- a/src/main/java/com/reandroid/dex/key/AnnotationItemKey.java
+++ b/src/main/java/com/reandroid/dex/key/AnnotationItemKey.java
@@ -27,7 +27,7 @@ import com.reandroid.utils.collection.*;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class AnnotationItemKey extends KeyList<AnnotationElementKey> implements Key, Iterable<AnnotationElementKey> {
 
@@ -141,7 +141,7 @@ public class AnnotationItemKey extends KeyList<AnnotationElementKey> implements 
         return (AnnotationItemKey) super.remove(index);
     }
     @Override
-    public AnnotationItemKey removeIf(Predicate<? super AnnotationElementKey> predicate) {
+    public AnnotationItemKey removeIf(org.apache.commons.collections4.Predicate<? super AnnotationElementKey> predicate) {
         return (AnnotationItemKey) super.removeIf(predicate);
     }
     @Override

--- a/src/main/java/com/reandroid/dex/key/AnnotationSetKey.java
+++ b/src/main/java/com/reandroid/dex/key/AnnotationSetKey.java
@@ -24,7 +24,7 @@ import com.reandroid.utils.collection.ComputeIterator;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class AnnotationSetKey extends KeyList<AnnotationItemKey> {
 
@@ -37,7 +37,7 @@ public class AnnotationSetKey extends KeyList<AnnotationItemKey> {
     public Iterator<TypeKey> getTypes() {
         return ComputeIterator.of(iterator(), AnnotationItemKey::getType);
     }
-    public AnnotationSetKey removeElementIf(TypeKey typeKey, Predicate<? super AnnotationElementKey> predicate) {
+    public AnnotationSetKey removeElementIf(TypeKey typeKey, org.apache.commons.collections4.Predicate<? super AnnotationElementKey> predicate) {
         AnnotationSetKey result = this;
         AnnotationItemKey itemKey = result.get(typeKey);
         if (itemKey == null) {
@@ -166,7 +166,7 @@ public class AnnotationSetKey extends KeyList<AnnotationItemKey> {
         return (AnnotationSetKey) super.remove(index);
     }
     @Override
-    public AnnotationSetKey removeIf(Predicate<? super AnnotationItemKey> predicate) {
+    public AnnotationSetKey removeIf(org.apache.commons.collections4.Predicate<? super AnnotationItemKey> predicate) {
         return (AnnotationSetKey) super.removeIf(predicate);
     }
     public AnnotationSetKey remove(TypeKey typeKey) {

--- a/src/main/java/com/reandroid/dex/key/ArrayKey.java
+++ b/src/main/java/com/reandroid/dex/key/ArrayKey.java
@@ -26,7 +26,7 @@ import com.reandroid.utils.collection.ArrayCollection;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Comparator;
-import java.util.function.Predicate;
+
 
 public class ArrayKey<T extends Key> extends KeyList<T> {
 
@@ -49,7 +49,7 @@ public class ArrayKey<T extends Key> extends KeyList<T> {
         return (ArrayKey<T>) super.remove(index);
     }
     @Override
-    public ArrayKey<T> removeIf(Predicate<? super T> predicate) {
+    public ArrayKey<T> removeIf(org.apache.commons.collections4.Predicate<? super T> predicate) {
         return (ArrayKey<T>) super.removeIf(predicate);
     }
     @Override

--- a/src/main/java/com/reandroid/dex/key/ArrayValueKey.java
+++ b/src/main/java/com/reandroid/dex/key/ArrayValueKey.java
@@ -23,7 +23,7 @@ import com.reandroid.utils.collection.ComputeIterator;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class ArrayValueKey extends ArrayKey<Key> {
 
@@ -120,7 +120,7 @@ public class ArrayValueKey extends ArrayKey<Key> {
         return (ArrayValueKey) super.remove(index);
     }
     @Override
-    public ArrayValueKey removeIf(Predicate<? super Key> predicate) {
+    public ArrayValueKey removeIf(org.apache.commons.collections4.Predicate<? super Key> predicate) {
         return (ArrayValueKey) super.removeIf(predicate);
     }
     @Override

--- a/src/main/java/com/reandroid/dex/key/KeyList.java
+++ b/src/main/java/com/reandroid/dex/key/KeyList.java
@@ -23,7 +23,7 @@ import com.reandroid.utils.collection.*;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public abstract class KeyList<T extends Key> implements Key, Iterable<T> {
 
@@ -59,7 +59,7 @@ public abstract class KeyList<T extends Key> implements Key, Iterable<T> {
     public Iterator<T> iterator() {
         return ArrayIterator.of(this.elements);
     }
-    public Iterator<T> iterator(Predicate<? super T> predicate) {
+    public Iterator<T> iterator(org.apache.commons.collections4.Predicate<? super T> predicate) {
         return ArrayIterator.of(this.elements, predicate);
     }
     public<T1 extends Key> Iterator<T1> iterator(Class<T1> instance) {
@@ -130,7 +130,7 @@ public abstract class KeyList<T extends Key> implements Key, Iterable<T> {
         return newInstance(result);
     }
     @SuppressWarnings("unchecked")
-    public KeyList<T> removeIf(Predicate<? super T> predicate) {
+    public KeyList<T> removeIf(org.apache.commons.collections4.Predicate<? super T> predicate) {
         Key[] elements = this.elements;
         int length = elements.length;
         if (length == 0) {
@@ -140,7 +140,7 @@ public abstract class KeyList<T extends Key> implements Key, Iterable<T> {
         int j = 0;
         for (int i = 0; i < length; i++) {
             T item = (T) elements[i];
-            if (predicate.test(item)) {
+            if (predicate.evaluate(item)) {
                 if (filtered == null) {
                     filtered = elements.clone();
                     j = i;

--- a/src/main/java/com/reandroid/dex/key/MethodKey.java
+++ b/src/main/java/com/reandroid/dex/key/MethodKey.java
@@ -29,7 +29,7 @@ import java.lang.annotation.ElementType;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.Iterator;
-import java.util.function.Function;
+import org.apache.commons.collections4.Transformer;
 
 public class MethodKey implements ProgramKey {
 
@@ -129,22 +129,22 @@ public class MethodKey implements ProgramKey {
                 getProto().mentionedKeys());
     }
 
-    public MethodKey replaceTypes(Function<TypeKey, TypeKey> function) {
+    public MethodKey replaceTypes(Transformer<TypeKey, TypeKey> function) {
         MethodKey result = this;
         TypeKey typeKey = getDeclaring();
-        typeKey = typeKey.changeTypeName(function.apply(typeKey));
+        typeKey = typeKey.changeTypeName(function.transformer(typeKey));
 
         result = result.changeDeclaring(typeKey);
 
         typeKey = getReturnType();
-        typeKey = typeKey.changeTypeName(function.apply(typeKey));
+        typeKey = typeKey.changeTypeName(function.transformer(typeKey));
 
         result = result.changeReturnType(typeKey);
 
         int count = getParametersCount();
         for(int i = 0; i < count; i++){
             typeKey = getParameter(i);
-            typeKey = typeKey.changeTypeName(function.apply(typeKey));
+            typeKey = typeKey.changeTypeName(function.transformer(typeKey));
             result = result.changeParameter(i, typeKey);
         }
         return result;
@@ -392,6 +392,8 @@ public class MethodKey implements ProgramKey {
         }
         return create(defining, StringKey.create(name), protoKey);
     }
+
+    //Not currently in use
     public static MethodKey convert(Method method) {
         TypeKey declaring = TypeKey.convert(method.getDeclaringClass());
         TypeKey returnType = TypeKey.convert(method.getReturnType());

--- a/src/main/java/com/reandroid/dex/model/DexClass.java
+++ b/src/main/java/com/reandroid/dex/model/DexClass.java
@@ -34,7 +34,7 @@ import java.io.*;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.function.Predicate;
+
 
 public class DexClass extends DexDeclaration implements ClassProgram, Comparable<DexClass> {
 
@@ -72,19 +72,19 @@ public class DexClass extends DexDeclaration implements ClassProgram, Comparable
     public Set<DexClass> getRequired(){
         return getRequired(null);
     }
-    public Set<DexClass> getRequired(Predicate<TypeKey> exclude){
+    public Set<DexClass> getRequired(org.apache.commons.collections4.Predicate<TypeKey> exclude){
         Set<DexClass> results = new HashSet<>();
         results.add(this);
         searchRequired(exclude, results);
         return results;
     }
-    private void searchRequired(Predicate<TypeKey> exclude, Set<DexClass> results){
+    private void searchRequired(org.apache.commons.collections4.Predicate<TypeKey> exclude, Set<DexClass> results){
         DexClassRepository dexClassRepository = getClassRepository();
         Iterator<TypeKey> iterator = usedTypes();
         while (iterator.hasNext()){
             TypeKey typeKey = iterator.next();
             typeKey = typeKey.getDeclaring();
-            if(exclude != null && !exclude.test(typeKey)){
+            if(exclude != null && !exclude.evaluate(typeKey)){
                 continue;
             }
             DexClass dexClass = dexClassRepository.getDexClass(typeKey);
@@ -333,7 +333,7 @@ public class DexClass extends DexDeclaration implements ClassProgram, Comparable
     public FieldDef getOrCreateInstance(FieldKey fieldKey){
         return getOrCreateClassData().getOrCreateInstance(fieldKey);
     }
-    public Iterator<DexMethod> getDeclaredMethods(Predicate<DexMethod> filter) {
+    public Iterator<DexMethod> getDeclaredMethods(org.apache.commons.collections4.Predicate<DexMethod> filter) {
         Iterator<DexMethod> iterator = getDeclaredMethods();
         if(filter == null){
             return iterator;
@@ -373,7 +373,7 @@ public class DexClass extends DexDeclaration implements ClassProgram, Comparable
     public Iterator<DexInstruction> getDexInstructions(){
         return getDexInstructions(null);
     }
-    public Iterator<DexInstruction> getDexInstructions(Predicate<DexMethod> filter){
+    public Iterator<DexInstruction> getDexInstructions(org.apache.commons.collections4.Predicate<DexMethod> filter){
         return new IterableIterator<DexMethod, DexInstruction>(getDeclaredMethods(filter)) {
             @Override
             public Iterator<DexInstruction> iterator(DexMethod element) {

--- a/src/main/java/com/reandroid/dex/model/DexClassModule.java
+++ b/src/main/java/com/reandroid/dex/model/DexClassModule.java
@@ -12,7 +12,7 @@ import com.reandroid.utils.collection.EmptyIterator;
 import com.reandroid.utils.collection.SingleIterator;
 
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public interface DexClassModule extends DexClassRepository {
 
@@ -32,10 +32,10 @@ public interface DexClassModule extends DexClassRepository {
     DexClass getOrCreateClass(TypeKey key);
 
     @Override
-    Iterator<DexClass> getDexClasses(Predicate<? super TypeKey> filter);
+    Iterator<DexClass> getDexClasses(org.apache.commons.collections4.Predicate<? super TypeKey> filter);
 
     @Override
-    Iterator<DexClass> getDexClassesCloned(Predicate<? super TypeKey> filter);
+    Iterator<DexClass> getDexClassesCloned(org.apache.commons.collections4.Predicate<? super TypeKey> filter);
 
     @Override
     boolean sort();
@@ -99,16 +99,16 @@ public interface DexClassModule extends DexClassRepository {
     }
 
     @Override
-    <T1 extends SectionItem> boolean removeEntries(SectionType<T1> sectionType, Predicate<T1> filter);
+    <T1 extends SectionItem> boolean removeEntries(SectionType<T1> sectionType, org.apache.commons.collections4.Predicate<T1> filter);
 
     @Override
-    <T1 extends SectionItem> boolean removeEntriesWithKey(SectionType<T1> sectionType, Predicate<? super Key> filter);
+    <T1 extends SectionItem> boolean removeEntriesWithKey(SectionType<T1> sectionType, org.apache.commons.collections4.Predicate<? super Key> filter);
 
     @Override
     <T1 extends SectionItem> boolean removeEntry(SectionType<T1> sectionType, Key key);
 
     @Override
-    boolean removeClasses(Predicate<? super DexClass> filter);
+    boolean removeClasses(org.apache.commons.collections4.Predicate<? super DexClass> filter);
 
     @Override
     void clearPoolMap();

--- a/src/main/java/com/reandroid/dex/model/DexClassRepository.java
+++ b/src/main/java/com/reandroid/dex/model/DexClassRepository.java
@@ -33,7 +33,7 @@ import com.reandroid.utils.collection.*;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Predicate;
+
 
 public interface DexClassRepository extends FullRefresh, BlockRefresh {
 
@@ -92,7 +92,7 @@ public interface DexClassRepository extends FullRefresh, BlockRefresh {
         return null;
     }
 
-    default Iterator<DexClass> getDexClasses(Predicate<? super TypeKey> filter) {
+    default Iterator<DexClass> getDexClasses(org.apache.commons.collections4.Predicate<? super TypeKey> filter) {
         return new IterableIterator<DexClassModule, DexClass>(modules()) {
             @Override
             public Iterator<DexClass> iterator(DexClassModule element) {
@@ -100,7 +100,7 @@ public interface DexClassRepository extends FullRefresh, BlockRefresh {
             }
         };
     }
-    default Iterator<DexClass> getDexClassesCloned(Predicate<? super TypeKey> filter) {
+    default Iterator<DexClass> getDexClassesCloned(org.apache.commons.collections4.Predicate<? super TypeKey> filter) {
         return new IterableIterator<DexClassModule, DexClass>(modules()) {
             @Override
             public Iterator<DexClass> iterator(DexClassModule element) {
@@ -156,15 +156,15 @@ public interface DexClassRepository extends FullRefresh, BlockRefresh {
         };
     }
     default <T extends SectionItem> Iterator<T> getClonedItemsIf(
-            SectionType<T> sectionType, Predicate<? super T> predicate) {
+            SectionType<T> sectionType, org.apache.commons.collections4.Predicate<? super T> predicate) {
         return FilterIterator.of(getClonedItems(sectionType), predicate);
     }
     default <T extends SectionItem> Iterator<T> getClonedItemsIfKey(
-            SectionType<T> sectionType, Predicate<? super Key> predicate) {
+            SectionType<T> sectionType, org.apache.commons.collections4.Predicate<? super Key> predicate) {
         if (predicate == null) {
             return getClonedItems(sectionType);
         }
-        return getClonedItemsIf(sectionType, item -> predicate.test(item.getKey()));
+        return getClonedItemsIf(sectionType, item -> predicate.evaluate(item.getKey()));
     }
     default <T extends SectionItem> Iterator<T> getItems(SectionType<T> sectionType, Key key) {
         return new IterableIterator<Section<T>, T>(getSections(sectionType)) {
@@ -175,7 +175,7 @@ public interface DexClassRepository extends FullRefresh, BlockRefresh {
         };
     }
     default <T extends SectionItem> Iterator<T> getItemsIf(
-            SectionType<T> sectionType, Predicate<? super T> predicate) {
+            SectionType<T> sectionType, org.apache.commons.collections4.Predicate<? super T> predicate) {
         return new IterableIterator<Section<T>, T>(getSections(sectionType)) {
             @Override
             public Iterator<T> iterator(Section<T> element) {
@@ -184,11 +184,11 @@ public interface DexClassRepository extends FullRefresh, BlockRefresh {
         };
     }
     default <T extends SectionItem> Iterator<T> getItemsIfKey(
-            SectionType<T> sectionType, Predicate<? super Key> predicate) {
+            SectionType<T> sectionType, org.apache.commons.collections4.Predicate<? super Key> predicate) {
         if (predicate == null) {
             return getItems(sectionType);
         }
-        return getItemsIf(sectionType, item -> predicate.test(item.getKey()));
+        return getItemsIf(sectionType, item -> predicate.evaluate(item.getKey()));
     }
     default <T extends SectionItem> T getItem(SectionType<T> sectionType, Key key) {
         Iterator<DexClassModule> iterator = modules();
@@ -237,7 +237,7 @@ public interface DexClassRepository extends FullRefresh, BlockRefresh {
         return contains(SectionType.CLASS_ID, key);
     }
 
-    default <T1 extends SectionItem> boolean removeEntries(SectionType<T1> sectionType, Predicate<T1> filter) {
+    default <T1 extends SectionItem> boolean removeEntries(SectionType<T1> sectionType, org.apache.commons.collections4.Predicate<T1> filter) {
         Iterator<DexClassModule> iterator = modules();
         boolean result = false;
         while (iterator.hasNext()) {
@@ -249,7 +249,7 @@ public interface DexClassRepository extends FullRefresh, BlockRefresh {
         return result;
     }
 
-    default <T1 extends SectionItem> boolean removeEntriesWithKey(SectionType<T1> sectionType, Predicate<? super Key> filter) {
+    default <T1 extends SectionItem> boolean removeEntriesWithKey(SectionType<T1> sectionType, org.apache.commons.collections4.Predicate<? super Key> filter) {
         Iterator<DexClassModule> iterator = modules();
         boolean result = false;
         while (iterator.hasNext()) {
@@ -368,7 +368,7 @@ public interface DexClassRepository extends FullRefresh, BlockRefresh {
         return removeEntry(SectionType.CLASS_ID, typeKey);
     }
 
-    default boolean removeClasses(Predicate<? super DexClass> filter) {
+    default boolean removeClasses(org.apache.commons.collections4.Predicate<? super DexClass> filter) {
         Iterator<DexClassModule> iterator = modules();
         boolean result = false;
         while (iterator.hasNext()) {
@@ -379,7 +379,7 @@ public interface DexClassRepository extends FullRefresh, BlockRefresh {
         }
         return result;
     }
-    default boolean removeClassesWithKeys(Predicate<? super TypeKey> filter) {
+    default boolean removeClassesWithKeys(org.apache.commons.collections4.Predicate<? super TypeKey> filter) {
         return removeEntriesWithKey(SectionType.CLASS_ID, ObjectsUtil.cast(filter));
     }
     default boolean removeAnnotations(TypeKey typeKey) {

--- a/src/main/java/com/reandroid/dex/model/DexDirectory.java
+++ b/src/main/java/com/reandroid/dex/model/DexDirectory.java
@@ -32,7 +32,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Predicate;
+
 
 public class DexDirectory implements Iterable<DexFile>, Closeable,
         DexClassRepository, FullRefresh {
@@ -666,7 +666,7 @@ public class DexDirectory implements Iterable<DexFile>, Closeable,
     public static DexDirectory fromZip(ZipEntryMap zipEntryMap) throws IOException {
         return fromZip(zipEntryMap, null);
     }
-    public static DexDirectory fromZip(ZipEntryMap zipEntryMap, Predicate<SectionType<?>> readFilter) throws IOException {
+    public static DexDirectory fromZip(ZipEntryMap zipEntryMap, org.apache.commons.collections4.Predicate<SectionType<?>> readFilter) throws IOException {
         DexDirectory dexDirectory = new DexDirectory();
         DexFileSourceSet sourceSet = dexDirectory.getDexSourceSet();
         sourceSet.setReadFilter(readFilter);
@@ -674,7 +674,7 @@ public class DexDirectory implements Iterable<DexFile>, Closeable,
         dexDirectory.updateDexFileList();
         return dexDirectory;
     }
-    public static DexDirectory fromDexFilesDirectory(File dir, Predicate<SectionType<?>> readFilter) throws IOException {
+    public static DexDirectory fromDexFilesDirectory(File dir, org.apache.commons.collections4.Predicate<SectionType<?>> readFilter) throws IOException {
         DexDirectory dexDirectory = new DexDirectory();
         DexFileSourceSet sourceSet = dexDirectory.getDexSourceSet();
         sourceSet.setReadFilter(readFilter);

--- a/src/main/java/com/reandroid/dex/model/DexFile.java
+++ b/src/main/java/com/reandroid/dex/model/DexFile.java
@@ -22,13 +22,14 @@ import com.reandroid.dex.smali.SmaliWriter;
 import com.reandroid.utils.CompareUtil;
 import com.reandroid.utils.ObjectsUtil;
 import com.reandroid.utils.collection.ArrayCollection;
+import com.reandroid.utils.collection.CollectionUtil;
 import com.reandroid.utils.collection.IterableIterator;
 import com.reandroid.utils.io.FileUtil;
 
 import java.io.*;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Predicate;
+
 
 public class DexFile implements Closeable, DexClassRepository, Iterable<DexLayout> {
 
@@ -247,7 +248,7 @@ public class DexFile implements Closeable, DexClassRepository, Iterable<DexLayou
     public void readBytes(BlockReader reader) throws IOException {
         getContainerBlock().readBytes(reader);
     }
-    public void readBytes(BlockReader reader, Predicate<SectionType<?>> filter) throws IOException {
+    public void readBytes(BlockReader reader, org.apache.commons.collections4.Predicate<SectionType<?>> filter) throws IOException {
         getContainerBlock().readBytes(reader, filter);
     }
     public void write(File file) throws IOException {
@@ -319,7 +320,7 @@ public class DexFile implements Closeable, DexClassRepository, Iterable<DexLayou
         if (results.isEmpty()) {
             return null;
         }
-        results.sort(CompareUtil.getToStringComparator());
+        java.util.Collections.sort(results, CompareUtil.getToStringComparator());
         return results;
     }
     private boolean isLayoutDirectory(File dir) {
@@ -473,16 +474,16 @@ public class DexFile implements Closeable, DexClassRepository, Iterable<DexLayou
     }
 
 
-    public static DexFile read(byte[] dexBytes, Predicate<SectionType<?>> filter) throws IOException {
+    public static DexFile read(byte[] dexBytes, org.apache.commons.collections4.Predicate<SectionType<?>> filter) throws IOException {
         return read(new BlockReader(dexBytes), filter);
     }
-    public static DexFile read(File file, Predicate<SectionType<?>> filter) throws IOException {
+    public static DexFile read(File file, org.apache.commons.collections4.Predicate<SectionType<?>> filter) throws IOException {
         return read(new BlockReader(file), filter);
     }
-    public static DexFile read(InputStream inputStream, Predicate<SectionType<?>> filter) throws IOException {
+    public static DexFile read(InputStream inputStream, org.apache.commons.collections4.Predicate<SectionType<?>> filter) throws IOException {
         return read(new BlockReader(inputStream), filter);
     }
-    public static DexFile read(BlockReader reader, Predicate<SectionType<?>> filter) throws IOException {
+    public static DexFile read(BlockReader reader, org.apache.commons.collections4.Predicate<SectionType<?>> filter) throws IOException {
         DexFile dexFile = new DexFile(new DexContainerBlock());
         dexFile.readBytes(reader, filter);
         return dexFile;

--- a/src/main/java/com/reandroid/dex/model/DexFileLayoutController.java
+++ b/src/main/java/com/reandroid/dex/model/DexFileLayoutController.java
@@ -22,6 +22,7 @@ import com.reandroid.utils.CompareUtil;
 import com.reandroid.utils.collection.ArrayCollection;
 import com.reandroid.utils.collection.ArraySupplierIterator;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -88,7 +89,7 @@ class DexFileLayoutController implements DexContainerBlock.LayoutBlockChangedLis
                 i --;
             }
         }
-        dexLayoutList.sort((layout1, layout2) -> CompareUtil.compare(layout1.getIndex(),
+        Collections.sort(dexLayoutList, (layout1, layout2) -> CompareUtil.compare(layout1.getIndex(),
                 layout2.getIndex()));
     }
 

--- a/src/main/java/com/reandroid/dex/model/DexFileSourceSet.java
+++ b/src/main/java/com/reandroid/dex/model/DexFileSourceSet.java
@@ -26,13 +26,13 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class DexFileSourceSet implements Iterable<DexSource<DexFile>>, Closeable {
 
     private final ArrayCollection<DexSource<DexFile>> sourceList;
     private ZipEntryMap zipEntryMap;
-    private Predicate<SectionType<?>> readFilter;
+    private org.apache.commons.collections4.Predicate<SectionType<?>> readFilter;
 
     public DexFileSourceSet(){
         this.sourceList = new ArrayCollection<>();
@@ -45,10 +45,10 @@ public class DexFileSourceSet implements Iterable<DexSource<DexFile>>, Closeable
         this.zipEntryMap = zipEntryMap;
     }
 
-    public Predicate<SectionType<?>> getReadFilter() {
+    public org.apache.commons.collections4.Predicate<SectionType<?>> getReadFilter() {
         return readFilter;
     }
-    public void setReadFilter(Predicate<SectionType<?>> readFilter) {
+    public void setReadFilter(org.apache.commons.collections4.Predicate<SectionType<?>> readFilter) {
         this.readFilter = readFilter;
     }
 
@@ -139,14 +139,14 @@ public class DexFileSourceSet implements Iterable<DexSource<DexFile>>, Closeable
             path = path + "/";
         }
         final String pathPrefix = path + "classes";
-        Predicate<InputSource> filter = inputSource -> {
+        org.apache.commons.collections4.Predicate<InputSource> filter = inputSource -> {
             String name = inputSource.getAlias();
 
             return name.startsWith(pathPrefix) && DexFile.getDexFileNumber(name) >= 0;
         };
         addAll(zipEntryMap, filter);
     }
-    public void addAll(ZipEntryMap zipEntryMap, Predicate<InputSource> filter) throws IOException {
+    public void addAll(ZipEntryMap zipEntryMap, org.apache.commons.collections4.Predicate<InputSource> filter) throws IOException {
         addAll(zipEntryMap, zipEntryMap.iterator(filter));
     }
     public void addAll(ZipEntryMap zipEntryMap, Iterator<InputSource> iterator) throws IOException {

--- a/src/main/java/com/reandroid/dex/model/DexInstruction.java
+++ b/src/main/java/com/reandroid/dex/model/DexInstruction.java
@@ -35,7 +35,7 @@ import com.reandroid.utils.collection.*;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Predicate;
+
 
 public class DexInstruction extends DexCode {
 
@@ -367,7 +367,7 @@ public class DexInstruction extends DexCode {
     public DexInstruction getPreviousReader(int register, Opcode<?> opcode) {
         return getPreviousReader(register, instruction -> instruction.is(opcode));
     }
-    public DexInstruction getPreviousReader(int register, Predicate<DexInstruction> predicate) {
+    public DexInstruction getPreviousReader(int register, org.apache.commons.collections4.Predicate<DexInstruction> predicate) {
         DexInstruction previous = getPrevious();
         while (previous != null) {
             Opcode<?> opcode = previous.getOpcode();
@@ -379,7 +379,7 @@ public class DexInstruction extends DexCode {
                 for(int i = 0; i < size; i++) {
                     if(register == previous.getRegister(i) &&
                             RegisterType.READ.is(format.get(i))) {
-                        if(predicate.test(previous)) {
+                        if(predicate.evaluate(previous)) {
                             return previous;
                         }
                         return null;
@@ -396,7 +396,7 @@ public class DexInstruction extends DexCode {
     public DexInstruction getPreviousSetter(int register, Opcode<?> opcode) {
         return getPreviousSetter(register, instruction -> instruction.is(opcode));
     }
-    public DexInstruction getPreviousSetter(int register, Predicate<DexInstruction> predicate) {
+    public DexInstruction getPreviousSetter(int register, org.apache.commons.collections4.Predicate<DexInstruction> predicate) {
         DexInstruction previous = getPrevious();
         while (previous != null) {
             Opcode<?> opcode = previous.getOpcode();
@@ -408,7 +408,7 @@ public class DexInstruction extends DexCode {
                 for(int i = 0; i < size; i++) {
                     if(register == previous.getRegister(i) &&
                             RegisterType.WRITE.is(format.get(i))) {
-                        if(predicate.test(previous)) {
+                        if(predicate.evaluate(previous)) {
                             return previous;
                         }
                         return null;

--- a/src/main/java/com/reandroid/dex/model/DexLayout.java
+++ b/src/main/java/com/reandroid/dex/model/DexLayout.java
@@ -35,7 +35,7 @@ import com.reandroid.utils.io.FileIterator;
 
 import java.io.*;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class DexLayout implements DexClassModule, Closeable,
         Iterable<DexClass> {
@@ -133,16 +133,16 @@ public class DexLayout implements DexClassModule, Closeable,
         return getDexClasses();
     }
     @Override
-    public boolean removeClasses(Predicate<? super DexClass> filter) {
-        Predicate<ClassId> classIdFilter = classId -> filter.test(DexLayout.this.create(classId));
+    public boolean removeClasses(org.apache.commons.collections4.Predicate<? super DexClass> filter) {
+        org.apache.commons.collections4.Predicate<ClassId> classIdFilter = classId -> filter.evaluate(DexLayout.this.create(classId));
         return getDexLayoutBlock().removeEntries(SectionType.CLASS_ID, classIdFilter);
     }
     @Override
-    public <T1 extends SectionItem> boolean removeEntries(SectionType<T1> sectionType, Predicate<T1> filter) {
+    public <T1 extends SectionItem> boolean removeEntries(SectionType<T1> sectionType, org.apache.commons.collections4.Predicate<T1> filter) {
         return getDexLayoutBlock().removeEntries(sectionType, filter);
     }
     @Override
-    public <T1 extends SectionItem> boolean removeEntriesWithKey(SectionType<T1> sectionType, Predicate<? super Key> filter) {
+    public <T1 extends SectionItem> boolean removeEntriesWithKey(SectionType<T1> sectionType, org.apache.commons.collections4.Predicate<? super Key> filter) {
         return getDexLayoutBlock().removeWithKeys(sectionType, filter);
     }
     @Override
@@ -158,11 +158,11 @@ public class DexLayout implements DexClassModule, Closeable,
         return create(classId);
     }
     @Override
-    public Iterator<DexClass> getDexClasses(Predicate<? super TypeKey> filter) {
+    public Iterator<DexClass> getDexClasses(org.apache.commons.collections4.Predicate<? super TypeKey> filter) {
         return ComputeIterator.of(getItemsIfKey(SectionType.CLASS_ID, ObjectsUtil.cast(filter)), this::create);
     }
     @Override
-    public Iterator<DexClass> getDexClassesCloned(Predicate<? super TypeKey> filter) {
+    public Iterator<DexClass> getDexClassesCloned(org.apache.commons.collections4.Predicate<? super TypeKey> filter) {
         return ComputeIterator.of(
                 getClonedItemsIfKey(SectionType.CLASS_ID, ObjectsUtil.cast(filter)),
                 this::create);

--- a/src/main/java/com/reandroid/dex/model/DexMethod.java
+++ b/src/main/java/com/reandroid/dex/model/DexMethod.java
@@ -32,7 +32,7 @@ import com.reandroid.utils.collection.*;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Predicate;
+
 
 public class DexMethod extends DexDeclaration implements MethodProgram {
 
@@ -175,7 +175,7 @@ public class DexMethod extends DexDeclaration implements MethodProgram {
     public Iterator<DexInstruction> getInstructions(Opcode<?> opcode) {
         return getInstructions(ins -> ins.getOpcode() == opcode);
     }
-    public Iterator<DexInstruction> getInstructions(Predicate<? super Ins> filter) {
+    public Iterator<DexInstruction> getInstructions(org.apache.commons.collections4.Predicate<? super Ins> filter) {
         Iterator<Ins> iterator = FilterIterator.of(getDefinition().getInstructions(), filter);
         return ComputeIterator.of(iterator, this::create);
     }

--- a/src/main/java/com/reandroid/dex/model/RClass.java
+++ b/src/main/java/com/reandroid/dex/model/RClass.java
@@ -30,6 +30,7 @@ import com.reandroid.dex.key.TypeKey;
 import com.reandroid.utils.CompareUtil;
 import com.reandroid.utils.StringsUtil;
 import com.reandroid.utils.collection.ArrayCollection;
+import com.reandroid.utils.collection.CollectionUtil;
 import com.reandroid.utils.collection.ComputeIterator;
 import com.reandroid.utils.collection.EmptyIterator;
 import com.reandroid.utils.io.IOUtil;
@@ -179,7 +180,7 @@ public class RClass extends DexClass {
 
         List<RField> fieldList = new ArrayCollection<>();
         fieldList.addAll(rFields);
-        fieldList.sort(CompareUtil.getComparableComparator());
+        java.util.Collections.sort(fieldList, CompareUtil.getComparableComparator());
         for(RField rField : fieldList) {
             rField.serializePublicXml(serializer);
         }

--- a/src/main/java/com/reandroid/dex/model/RClassParent.java
+++ b/src/main/java/com/reandroid/dex/model/RClassParent.java
@@ -28,6 +28,7 @@ import com.reandroid.dex.key.MethodKey;
 import com.reandroid.dex.key.TypeKey;
 import com.reandroid.utils.CompareUtil;
 import com.reandroid.utils.collection.ArrayCollection;
+import com.reandroid.utils.collection.CollectionUtil;
 import com.reandroid.utils.io.IOUtil;
 import org.xmlpull.v1.XmlSerializer;
 
@@ -123,7 +124,7 @@ public class RClassParent extends DexClass {
 
         List<RField> fieldList = new ArrayCollection<>();
         fieldList.addAll(rFields);
-        fieldList.sort(CompareUtil.getComparableComparator());
+        java.util.Collections.sort(fieldList, CompareUtil.getComparableComparator());
         for(RField rField : fieldList) {
             rField.serializePublicXml(serializer);
         }

--- a/src/main/java/com/reandroid/dex/model/RField.java
+++ b/src/main/java/com/reandroid/dex/model/RField.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.function.Predicate;
+
 
 public class RField extends DexField implements Comparable<RField> {
 
@@ -199,7 +199,7 @@ public class RField extends DexField implements Comparable<RField> {
             return EmptyIterator.of();
         }
         @Override
-        public Iterator<Entry> iterator(Predicate<? super Entry> filter) {
+        public Iterator<Entry> iterator(org.apache.commons.collections4.Predicate<? super Entry> filter) {
             return EmptyIterator.of();
         }
         public RField getRField() {

--- a/src/main/java/com/reandroid/dex/program/AnnotatedProgram.java
+++ b/src/main/java/com/reandroid/dex/program/AnnotatedProgram.java
@@ -19,7 +19,7 @@ import com.reandroid.dex.key.AnnotationItemKey;
 import com.reandroid.dex.key.AnnotationSetKey;
 import com.reandroid.dex.key.TypeKey;
 
-import java.util.function.Predicate;
+
 
 public interface AnnotatedProgram {
 
@@ -32,7 +32,7 @@ public interface AnnotatedProgram {
                 .add(annotation);
         setAnnotation(key);
     }
-    default boolean removeAnnotationIf(Predicate<? super AnnotationItemKey> predicate) {
+    default boolean removeAnnotationIf(org.apache.commons.collections4.Predicate<? super AnnotationItemKey> predicate) {
         AnnotationSetKey key = getAnnotation();
         AnnotationSetKey update = key.removeIf(predicate);
         if (key.equals(update)) {

--- a/src/main/java/com/reandroid/dex/refactor/Rename.java
+++ b/src/main/java/com/reandroid/dex/refactor/Rename.java
@@ -22,6 +22,7 @@ import com.reandroid.utils.CompareUtil;
 import com.reandroid.utils.ObjectsUtil;
 import com.reandroid.utils.StringsUtil;
 import com.reandroid.utils.collection.ArrayCollection;
+import com.reandroid.utils.collection.CollectionUtil;
 
 import java.util.*;
 
@@ -187,7 +188,7 @@ public abstract class Rename<T extends Key, R extends Key> {
     public List<KeyPair<T, R>> toList(Comparator<KeyPair<? super T, ? super R>> comparator) {
         List<KeyPair<T, R>> results = new ArrayCollection<>(getKeyPairSet());
         if (comparator != null) {
-            results.sort(comparator);
+            java.util.Collections.sort(results, comparator);
         }
         return results;
     }

--- a/src/main/java/com/reandroid/dex/sections/DexContainerBlock.java
+++ b/src/main/java/com/reandroid/dex/sections/DexContainerBlock.java
@@ -28,7 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 
 public class DexContainerBlock extends BlockList<DexLayoutBlock> implements
@@ -173,7 +173,7 @@ public class DexContainerBlock extends BlockList<DexLayoutBlock> implements
     public void readChildes(BlockReader reader) throws IOException {
         readBytes(reader, null);
     }
-    public void readBytes(BlockReader reader, Predicate<SectionType<?>> filter) throws IOException {
+    public void readBytes(BlockReader reader, org.apache.commons.collections4.Predicate<SectionType<?>> filter) throws IOException {
         int size = size();
         for (int i = 0; i < size; i++) {
             DexLayoutBlock layoutBlock = get(i);

--- a/src/main/java/com/reandroid/dex/sections/DexLayoutBlock.java
+++ b/src/main/java/com/reandroid/dex/sections/DexLayoutBlock.java
@@ -35,7 +35,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class DexLayoutBlock extends FixedBlockContainer implements FullRefresh {
 
@@ -228,14 +228,14 @@ public class DexLayoutBlock extends FixedBlockContainer implements FullRefresh {
         }
         return EmptyIterator.of();
     }
-    public <T1 extends SectionItem> boolean removeEntries(SectionType<T1> sectionType, Predicate<T1> filter){
+    public <T1 extends SectionItem> boolean removeEntries(SectionType<T1> sectionType, org.apache.commons.collections4.Predicate<T1> filter){
         Section<T1> section = getSection(sectionType);
         if(section != null){
             return section.removeEntries(filter);
         }
         return false;
     }
-    public <T1 extends SectionItem> boolean removeWithKeys(SectionType<T1> sectionType, Predicate<? super Key> filter){
+    public <T1 extends SectionItem> boolean removeWithKeys(SectionType<T1> sectionType, org.apache.commons.collections4.Predicate<? super Key> filter){
         Section<T1> section = getSection(sectionType);
         if(section != null){
             return section.removeWithKeys(filter);
@@ -311,7 +311,7 @@ public class DexLayoutBlock extends FixedBlockContainer implements FullRefresh {
         return outputStream.toByteArray();
     }
 
-    public void readBytes(BlockReader reader, Predicate<SectionType<?>> filter) throws IOException {
+    public void readBytes(BlockReader reader, org.apache.commons.collections4.Predicate<SectionType<?>> filter) throws IOException {
         getSectionList().readSections(reader, filter);
     }
     public void write(File file) throws IOException {

--- a/src/main/java/com/reandroid/dex/sections/IdSection.java
+++ b/src/main/java/com/reandroid/dex/sections/IdSection.java
@@ -22,7 +22,7 @@ import com.reandroid.dex.key.Key;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.function.Predicate;
+
 
 public class IdSection<T extends IdItem> extends Section<T> {
 
@@ -52,8 +52,8 @@ public class IdSection<T extends IdItem> extends Section<T> {
         return false;
     }
     @Override
-    public boolean removeWithKeys(Predicate<? super Key> filter){
-        return getItemArray().removeIf(item -> filter.test(item.getKey()));
+    public boolean removeWithKeys(org.apache.commons.collections4.Predicate<? super Key> filter){
+        return getItemArray().removeIf(item -> filter.evaluate(item.getKey()));
     }
     @Override
     public T getSectionItem(int i){

--- a/src/main/java/com/reandroid/dex/sections/Section.java
+++ b/src/main/java/com/reandroid/dex/sections/Section.java
@@ -28,7 +28,7 @@ import com.reandroid.utils.CompareUtil;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class Section<T extends SectionItem>  extends FixedDexContainer
         implements DexArraySupplier<T>, OffsetSupplier,
@@ -69,10 +69,10 @@ public class Section<T extends SectionItem>  extends FixedDexContainer
     public boolean remove(Key key){
         return false;
     }
-    public boolean removeWithKeys(Predicate<? super Key> filter){
+    public boolean removeWithKeys(org.apache.commons.collections4.Predicate<? super Key> filter){
         return false;
     }
-    public boolean removeEntries(Predicate<? super T> filter){
+    public boolean removeEntries(org.apache.commons.collections4.Predicate<? super T> filter){
         return getItemArray().removeIf(filter);
     }
     void clearUsageTypes(){
@@ -202,7 +202,7 @@ public class Section<T extends SectionItem>  extends FixedDexContainer
     public Iterator<T> iterator() {
         return getItemArray().iterator();
     }
-    public Iterator<T> iterator(Predicate<? super T> filter) {
+    public Iterator<T> iterator(org.apache.commons.collections4.Predicate<? super T> filter) {
         return getItemArray().iterator(filter);
     }
     public Iterator<T> arrayIterator() {

--- a/src/main/java/com/reandroid/dex/sections/SectionList.java
+++ b/src/main/java/com/reandroid/dex/sections/SectionList.java
@@ -38,7 +38,7 @@ import com.reandroid.utils.collection.CombiningIterator;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.function.Predicate;
+
 
 public class SectionList extends FixedBlockContainer
         implements SectionTool, OffsetSupplier, Iterable<Section<?>> ,
@@ -171,7 +171,7 @@ public class SectionList extends FixedBlockContainer
     public void onReadBytes(BlockReader reader) throws IOException {
         readSections(reader, null);
     }
-    void readSections(BlockReader reader, Predicate<SectionType<?>> filter) throws IOException {
+    void readSections(BlockReader reader, org.apache.commons.collections4.Predicate<SectionType<?>> filter) throws IOException {
         mReading = true;
         int position = reader.getPosition();
         DexHeader header = getHeader();
@@ -185,13 +185,13 @@ public class SectionList extends FixedBlockContainer
         getSection(SectionType.HEADER).readBytes(reader);
         getSection(SectionType.MAP_LIST).readBytes(reader);
     }
-    private void readBody(BlockReader reader, Predicate<SectionType<?>> filter) throws IOException {
+    private void readBody(BlockReader reader, org.apache.commons.collections4.Predicate<SectionType<?>> filter) throws IOException {
         MapItem[] mapItemList = mapList.getBodyReaderSorted();
         int length = mapItemList.length;
         for (int i = 0; i < length; i++) {
             MapItem mapItem = mapItemList[i];
             SectionType<SectionItem> sectionType = mapItem.getSectionType();
-            if (filter == null || filter.test(sectionType)) {
+            if (filter == null || filter.evaluate(sectionType)) {
                 loadSection(mapItem, reader);
             }
         }

--- a/src/main/java/com/reandroid/dex/sections/SectionType.java
+++ b/src/main/java/com/reandroid/dex/sections/SectionType.java
@@ -28,7 +28,7 @@ import com.reandroid.utils.collection.ArrayIterator;
 
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.function.Function;
+import org.apache.commons.collections4.Transformer;
 
 
 public abstract class SectionType<T extends SectionItem> implements Creator<T> {
@@ -809,10 +809,10 @@ public abstract class SectionType<T extends SectionItem> implements Creator<T> {
     public static Iterator<SectionType<?>> getSectionTypes(){
         return new ArrayIterator<>(R8_ORDER);
     }
-    public static<T1> Comparator<T1> getReadComparator(Function<? super T1, SectionType<?>> function){
+    public static<T1> Comparator<T1> getReadComparator(Transformer<? super T1, SectionType<?>> function){
         return comparator(READ_ORDER, function);
     }
-    public static<T1> Comparator<T1> comparator(SectionType<?>[] sortOrder, Function<? super T1, SectionType<?>> function){
+    public static<T1> Comparator<T1> comparator(SectionType<?>[] sortOrder, Transformer<? super T1, SectionType<?>> function){
         return new OrderBasedComparator<>(sortOrder, function);
     }
     public static SectionType<?>[] getR8Order() {
@@ -835,10 +835,10 @@ public abstract class SectionType<T extends SectionItem> implements Creator<T> {
 
 
     static class OrderBasedComparator<T1> implements Comparator<T1> {
-        private final Function<? super T1, SectionType<?>> function;
+        private final Transformer<? super T1, SectionType<?>> function;
         private final SectionType<?>[] sortOrder;
 
-        public OrderBasedComparator(SectionType<?>[] sortOrder, Function<? super T1, SectionType<?>> function){
+        public OrderBasedComparator(SectionType<?>[] sortOrder, Transformer<? super T1, SectionType<?>> function){
             this.sortOrder = sortOrder;
             this.function = function;
         }
@@ -856,7 +856,7 @@ public abstract class SectionType<T extends SectionItem> implements Creator<T> {
             if(item == null){
                 return this.sortOrder.length - 1;
             }
-            return getOrder(this.function.apply(item));
+            return getOrder(this.function.transformer(item));
         }
         @Override
         public int compare(T1 item1, T1 item2) {

--- a/src/main/java/com/reandroid/dex/smali/SmaliReader.java
+++ b/src/main/java/com/reandroid/dex/smali/SmaliReader.java
@@ -20,6 +20,7 @@ import com.reandroid.common.Origin;
 import com.reandroid.common.TextPosition;
 import com.reandroid.utils.HexUtil;
 import com.reandroid.utils.NumbersUtil;
+import com.reandroid.utils.StringsUtil;
 import com.reandroid.utils.io.IOUtil;
 
 import java.io.File;
@@ -79,10 +80,10 @@ public class SmaliReader {
         return this.byteSource.read(i);
     }
     public String getString(int length){
-        return new String(getBytes(length), StandardCharsets.UTF_8);
+        return new String(getBytes(length), com.reandroid.utils.StringsUtil.UTF_8);
     }
     public String readString(int length){
-        return new String(readBytes(length), StandardCharsets.UTF_8);
+        return new String(readBytes(length), com.reandroid.utils.StringsUtil.UTF_8);
     }
     public String readEscapedString(char stopChar) throws IOException{
         int position = position();
@@ -539,7 +540,7 @@ public class SmaliReader {
         return (char) i;
     }
     public static SmaliReader of(String text){
-        SmaliReader reader = new SmaliReader(text.getBytes(StandardCharsets.UTF_8));
+        SmaliReader reader = new SmaliReader(StringsUtil.getBytesOfString(text, "UTF-8"));
         reader.setOrigin(Origin.createNew("<text-source>"));
         return reader;
     }

--- a/src/main/java/com/reandroid/dex/smali/formatters/SequentialLabelFactory.java
+++ b/src/main/java/com/reandroid/dex/smali/formatters/SequentialLabelFactory.java
@@ -19,6 +19,7 @@ import com.reandroid.dex.ins.Label;
 import com.reandroid.utils.CompareUtil;
 import com.reandroid.utils.HexUtil;
 import com.reandroid.utils.collection.ArrayCollection;
+import com.reandroid.utils.collection.CollectionUtil;
 
 import java.util.*;
 
@@ -53,7 +54,7 @@ public class SequentialLabelFactory {
     private void build(String key, Set<String> group) {
         Map<String, String> labelMap = this.labelMap;
         List<String> list = new ArrayCollection<>(group);
-        list.sort((s, t1) -> CompareUtil.compare(getLabelSuffix(s), getLabelSuffix(t1)));
+        java.util.Collections.sort(list, (Comparator<String>) (s, t1) -> CompareUtil.compare(getLabelSuffix(s), getLabelSuffix(t1)));
         int size = list.size();
         for(int i = 0; i < size; i++) {
             labelMap.put(list.get(i), HexUtil.toHex(key, i, 1));

--- a/src/main/java/com/reandroid/dex/smali/formatters/SmaliComment.java
+++ b/src/main/java/com/reandroid/dex/smali/formatters/SmaliComment.java
@@ -24,6 +24,7 @@ import com.reandroid.utils.collection.CollectionUtil;
 import com.reandroid.utils.collection.ComputeIterator;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -36,7 +37,7 @@ public interface SmaliComment {
         List<TypeKey> typeKeyList = CollectionUtil.toList(
                 ComputeIterator.of(iterator, DexDeclaration::getDefining));
 
-        typeKeyList.sort(CompareUtil.getComparableComparator());
+        Collections.sort( typeKeyList, CompareUtil.getComparableComparator());
 
         int size = typeKeyList.size();
         int remaining = 0;

--- a/src/main/java/com/reandroid/dex/smali/model/SmaliSet.java
+++ b/src/main/java/com/reandroid/dex/smali/model/SmaliSet.java
@@ -17,12 +17,15 @@ package com.reandroid.dex.smali.model;
 
 import com.reandroid.dex.smali.SmaliReader;
 import com.reandroid.dex.smali.SmaliWriter;
+import com.reandroid.utils.StringsUtil;
 import com.reandroid.utils.collection.ArrayCollection;
 import com.reandroid.utils.collection.InstanceIterator;
 
+import org.apache.commons.collections4.Predicate;
+
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class SmaliSet<T extends Smali> extends Smali{
 
@@ -91,11 +94,24 @@ public class SmaliSet<T extends Smali> extends Smali{
     public T remove(int i) {
         return body.remove(i);
     }
-    public boolean removeIf(Predicate<? super T> filter){
+    public boolean removeIf(org.apache.commons.collections4.Predicate<? super T> filter){
         return body.removeIf(filter);
     }
     public boolean removeInstances(Class<?> instance){
-        return body.removeIf(instance::isInstance);
+        ArrayCollection<String> results = new ArrayCollection<>(
+                StringsUtil.split("full", '\n', true));
+        results.removeIf(new org.apache.commons.collections4.Predicate<String>() {
+            @Override
+            public boolean evaluate(String text) {
+                return StringsUtil.isEmpty(text);
+            }
+        });
+        return body.removeIf(new Predicate<T>() {
+            @Override
+            public boolean evaluate(T obj) {
+                return instance.isInstance(obj);
+            }
+        });
     }
     public void clear(){
         for (T smali : body) {

--- a/src/main/java/com/reandroid/dex/value/ArrayValue.java
+++ b/src/main/java/com/reandroid/dex/value/ArrayValue.java
@@ -27,7 +27,7 @@ import com.reandroid.utils.collection.IterableIterator;
 
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class ArrayValue extends DexValueBlock<EncodedArray>
         implements Iterable<DexValueBlock<?>> {
@@ -58,7 +58,7 @@ public class ArrayValue extends DexValueBlock<EncodedArray>
     public boolean remove(DexValueBlock<?> value){
         return getValueContainer().remove(value);
     }
-    public boolean removeIf(Predicate<? super DexValueBlock<?>> filter){
+    public boolean removeIf(org.apache.commons.collections4.Predicate<? super DexValueBlock<?>> filter){
         return getValueContainer().removeIf(filter);
     }
     public<T1 extends DexValueBlock<?>> T1 createNext(DexValueType<T1> valueType){
@@ -76,7 +76,7 @@ public class ArrayValue extends DexValueBlock<EncodedArray>
     public<T1 extends DexValueBlock<?>> Iterator<T1> iterator(Class<T1> instance) {
         return getValueContainer().iterator(instance);
     }
-    public<T1 extends DexValueBlock<?>> Iterator<T1> iterator(Class<T1> instance, Predicate<? super T1> filter){
+    public<T1 extends DexValueBlock<?>> Iterator<T1> iterator(Class<T1> instance, org.apache.commons.collections4.Predicate<? super T1> filter){
         return getValueContainer().iterator(instance, filter);
     }
     public Iterator<DexValueBlock<?>> clonedIterator() {

--- a/src/main/java/com/reandroid/graph/ApkBuildOption.java
+++ b/src/main/java/com/reandroid/graph/ApkBuildOption.java
@@ -24,7 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.function.Predicate;
+
 
 public class ApkBuildOption {
 
@@ -38,7 +38,7 @@ public class ApkBuildOption {
     private boolean processClassNamesOnStrings = true;
 
     private ResourceMergeOption mMergeOption;
-    private Predicate<? super TypeKey> keepClassesFilter;
+    private org.apache.commons.collections4.Predicate<? super TypeKey> keepClassesFilter;
     private final Set<TypeKey> keepClassesList = new HashSet<>();
 
     public ApkBuildOption() {
@@ -98,21 +98,21 @@ public class ApkBuildOption {
         this.mMergeOption = mergeOption;
     }
 
-    public Predicate<? super TypeKey> getKeepClasses() {
+    public org.apache.commons.collections4.Predicate<? super TypeKey> getKeepClasses() {
         return CollectionUtil.orFilter(getKeepClassesFilter(),
                 getKeepClassesListFilter());
     }
-    public Predicate<? super TypeKey> getKeepClassesFilter() {
+    public org.apache.commons.collections4.Predicate<? super TypeKey> getKeepClassesFilter() {
         return keepClassesFilter;
     }
-    public void setKeepClassesFilter(Predicate<? super TypeKey> filter) {
+    public void setKeepClassesFilter(org.apache.commons.collections4.Predicate<? super TypeKey> filter) {
         this.keepClassesFilter = filter;
     }
 
-    public Predicate<? super TypeKey> getKeepClassesListFilter() {
+    public org.apache.commons.collections4.Predicate<? super TypeKey> getKeepClassesListFilter() {
         Set<TypeKey> keepClassesList = this.keepClassesList;
         if(!keepClassesList.isEmpty()) {
-            return (Predicate<TypeKey>) keepClassesList::contains;
+            return (org.apache.commons.collections4.Predicate<TypeKey>) keepClassesList::contains;
         }
         return null;
     }

--- a/src/main/java/com/reandroid/graph/BaseDexClassProcessor.java
+++ b/src/main/java/com/reandroid/graph/BaseDexClassProcessor.java
@@ -20,7 +20,7 @@ import com.reandroid.dex.model.DexClassRepository;
 import com.reandroid.utils.collection.FilterIterator;
 
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public abstract class BaseDexClassProcessor extends GraphTask {
 
@@ -30,7 +30,7 @@ public abstract class BaseDexClassProcessor extends GraphTask {
         this.classRepository = classRepository;
     }
 
-    public Iterator<DexClass> getDexClasses(Predicate<? super DexClass> filter) {
+    public Iterator<DexClass> getDexClasses(org.apache.commons.collections4.Predicate<? super DexClass> filter) {
         return FilterIterator.of(getClassRepository().getDexClasses(), filter);
     }
     public DexClassRepository getClassRepository() {

--- a/src/main/java/com/reandroid/graph/InlineFieldIntResolver.java
+++ b/src/main/java/com/reandroid/graph/InlineFieldIntResolver.java
@@ -25,14 +25,14 @@ import com.reandroid.dex.key.TypeKey;
 import com.reandroid.dex.model.*;
 
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class InlineFieldIntResolver extends BaseDexClassProcessor {
 
-    private final Predicate<Integer> resourceIdChecker;
+    private final org.apache.commons.collections4.Predicate<Integer> resourceIdChecker;
     private int mResolvedCount;
 
-    public InlineFieldIntResolver(DexClassRepository classRepository, Predicate<Integer> resourceIdChecker) {
+    public InlineFieldIntResolver(DexClassRepository classRepository, org.apache.commons.collections4.Predicate<Integer> resourceIdChecker) {
         super(classRepository);
         this.resourceIdChecker = resourceIdChecker;
     }
@@ -94,7 +94,7 @@ public class InlineFieldIntResolver extends BaseDexClassProcessor {
             return;
         }
         int id = ((PrimitiveKey.IntegerKey) value).value();
-        if(!resourceIdChecker.test(id)) {
+        if(!resourceIdChecker.evaluate(id)) {
             return;
         }
         Key key = instruction.getKey();
@@ -112,14 +112,14 @@ public class InlineFieldIntResolver extends BaseDexClassProcessor {
         this.mResolvedCount = 0;
     }
 
-    private static Predicate<Integer> createChecker(TableBlock tableBlock) {
+    private static org.apache.commons.collections4.Predicate<Integer> createChecker(TableBlock tableBlock) {
         return id -> {
             int i = id;
             return PackageBlock.isResourceId(i) &&
                     tableBlock.getResource(i) != null;
         };
     }
-    private static Predicate<Integer> createDefaultChecker() {
+    private static org.apache.commons.collections4.Predicate<Integer> createDefaultChecker() {
         return PackageBlock::isResourceId;
     }
 }

--- a/src/main/java/com/reandroid/graph/RequiredEntriesScanner.java
+++ b/src/main/java/com/reandroid/graph/RequiredEntriesScanner.java
@@ -31,7 +31,7 @@ import com.reandroid.utils.collection.FilterIterator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.function.Predicate;
+
 
 public class RequiredEntriesScanner extends BaseApkModuleProcessor{
 
@@ -67,7 +67,7 @@ public class RequiredEntriesScanner extends BaseApkModuleProcessor{
     }
 
     private void scanUserConfigs() {
-        Predicate<? super ResourceName> filter = buildOption.getResourceMergeOption()
+        org.apache.commons.collections4.Predicate<? super ResourceName> filter = buildOption.getResourceMergeOption()
                 .getKeepResourceName();
         if(filter == null) {
             return;
@@ -75,7 +75,7 @@ public class RequiredEntriesScanner extends BaseApkModuleProcessor{
         Iterator<ResourceEntry> iterator = FilterIterator.of(getTableBlock().getResources(),
                 resourceEntry -> {
                     ResourceName resourceName = resourceEntry.toResourceName();
-                    return resourceName != null && filter.test(resourceName);
+                    return resourceName != null && filter.evaluate(resourceName);
                 });
         while (iterator.hasNext()) {
             add(iterator.next());

--- a/src/main/java/com/reandroid/graph/VitalClassesSet.java
+++ b/src/main/java/com/reandroid/graph/VitalClassesSet.java
@@ -40,9 +40,9 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Predicate;
 
-public class VitalClassesSet extends BaseApkModuleProcessor implements Predicate<TypeKey> {
+
+public class VitalClassesSet extends BaseApkModuleProcessor implements org.apache.commons.collections4.Predicate<TypeKey> {
 
     private final ApkBuildOption buildOption;
     private final Set<TypeKey> mainClasses;
@@ -66,7 +66,7 @@ public class VitalClassesSet extends BaseApkModuleProcessor implements Predicate
         return sourceStringClasses.iterator();
     }
     @Override
-    public boolean test(TypeKey typeKey) {
+    public boolean evaluate(TypeKey typeKey) {
         return mainClasses.contains(typeKey);
     }
     public boolean containsSourceString(TypeKey typeKey) {
@@ -233,7 +233,7 @@ public class VitalClassesSet extends BaseApkModuleProcessor implements Predicate
     private void scanRequiredByUser() {
         keepClasses(getBuildOption().getKeepClasses());
     }
-    public void keepClasses(Predicate<? super TypeKey> filter) {
+    public void keepClasses(org.apache.commons.collections4.Predicate<? super TypeKey> filter) {
         if(filter == null) {
             return;
         }

--- a/src/main/java/com/reandroid/graph/cleaners/UnusedClassComponentCleaner.java
+++ b/src/main/java/com/reandroid/graph/cleaners/UnusedClassComponentCleaner.java
@@ -25,7 +25,7 @@ import com.reandroid.graph.ApkBuildOption;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Predicate;
+
 
 public abstract class UnusedClassComponentCleaner<T extends Dex> extends UnusedCleaner<T> {
 
@@ -73,8 +73,8 @@ public abstract class UnusedClassComponentCleaner<T extends Dex> extends UnusedC
         if(dexClass.usesNative() || dexClass.isEnum()) {
             return false;
         }
-        Predicate<? super TypeKey> filter = getBuildOption().getKeepClasses();
-        if(filter != null && filter.test(dexClass.getKey())) {
+        org.apache.commons.collections4.Predicate<? super TypeKey> filter = getBuildOption().getKeepClasses();
+        if(filter != null && filter.evaluate(dexClass.getKey())) {
             return false;
         }
         // TODO: add user rules here

--- a/src/main/java/com/reandroid/identifiers/IdentifierMap.java
+++ b/src/main/java/com/reandroid/identifiers/IdentifierMap.java
@@ -15,6 +15,8 @@
  */
 package com.reandroid.identifiers;
 
+import com.reandroid.utils.collection.CollectionUtil;
+
 import java.util.*;
 
 class IdentifierMap<CHILD extends Identifier> extends Identifier
@@ -50,7 +52,7 @@ class IdentifierMap<CHILD extends Identifier> extends Identifier
                 uniques.put(name, item);
             }
         }
-        results.sort(this);
+        Collections.sort(results, this);
         return results;
     }
     public boolean hasDuplicates(){
@@ -74,7 +76,7 @@ class IdentifierMap<CHILD extends Identifier> extends Identifier
     }
     public List<CHILD> list(){
         List<CHILD> childList = new ArrayList<>(getItems());
-        childList.sort(this);
+        Collections.sort(childList,this);
         return childList;
     }
     public Collection<CHILD> getItems(){

--- a/src/main/java/com/reandroid/identifiers/PackageIdentifier.java
+++ b/src/main/java/com/reandroid/identifiers/PackageIdentifier.java
@@ -157,7 +157,7 @@ public class PackageIdentifier extends IdentifierMap<TypeIdentifier>{
     }
     public void writePublicXml(OutputStream outputStream) throws IOException {
         XmlSerializer serializer = XMLFactory.newSerializer(outputStream);
-        serializer.setOutput(outputStream, StandardCharsets.UTF_8.name());
+        serializer.setOutput(outputStream, com.reandroid.utils.StringsUtil.UTF_8.name());
         write(serializer);
     }
     public void write(XmlSerializer serializer) throws IOException {

--- a/src/main/java/com/reandroid/json/Cookie.java
+++ b/src/main/java/com/reandroid/json/Cookie.java
@@ -5,6 +5,8 @@
 */
 package com.reandroid.json;
 
+import com.reandroid.utils.StringsUtil;
+
 import java.util.Locale;
 
 public class Cookie {
@@ -48,7 +50,7 @@ public class Cookie {
         x.next();
         // parse the remaining cookie attributes
         while (x.more()) {
-            name = unescape(x.nextTo("=;")).trim().toLowerCase(Locale.ROOT);
+            name = StringsUtil.toLowerCaseWithLocale(unescape(x.nextTo("=;")).trim());
             // don't allow a cookies attributes to overwrite it's name or value.
             if("name".equalsIgnoreCase(name)) {
                 throw new JSONException("Illegal attribute name: 'name'");

--- a/src/main/java/com/reandroid/json/HTTP.java
+++ b/src/main/java/com/reandroid/json/HTTP.java
@@ -5,6 +5,8 @@
 */
 package com.reandroid.json;
 
+import com.reandroid.utils.StringsUtil;
+
 import java.util.Locale;
 
 public class HTTP {
@@ -18,7 +20,7 @@ public class HTTP {
         String         token;
 
         token = x.nextToken();
-        if (token.toUpperCase(Locale.ROOT).startsWith("HTTP")) {
+        if (StringsUtil.toUpperCaseWithLocale(token).startsWith("HTTP")) {
 
 // Response
 

--- a/src/main/java/com/reandroid/json/JSONArray.java
+++ b/src/main/java/com/reandroid/json/JSONArray.java
@@ -6,6 +6,7 @@
 package com.reandroid.json;
 
 import com.reandroid.common.FileChannelInputStream;
+import com.reandroid.utils.collection.CollectionUtil;
 
 import java.io.*;
 import java.lang.reflect.Array;
@@ -13,6 +14,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -697,7 +699,7 @@ public class JSONArray extends JSONItem implements Iterable<Object> {
     }
 
     public void sort(Comparator comparator) {
-        this.myArrayList.sort(comparator);
+        Collections.sort(this.myArrayList, comparator);
     }
 
     private void addAll(Collection<?> collection, boolean wrap) {

--- a/src/main/java/com/reandroid/json/JSONItem.java
+++ b/src/main/java/com/reandroid/json/JSONItem.java
@@ -15,11 +15,11 @@
  */
 package com.reandroid.json;
 
+import com.reandroid.utils.StringsUtil;
+
 import java.io.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.Map;
 
@@ -43,7 +43,7 @@ public abstract class JSONItem {
         write(outputStream, INDENT_FACTOR);
     }
     public void write(OutputStream outputStream, int indentFactor) throws IOException {
-        Writer writer=new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
+        Writer writer=new OutputStreamWriter(outputStream, com.reandroid.utils.StringsUtil.UTF_8);
         writer= write(writer, indentFactor, 0);
         writer.flush();
         writer.close();
@@ -121,7 +121,7 @@ public abstract class JSONItem {
     }
 
     public static Writer quote(String string, Writer w) throws IOException {
-        if (string == null || string.isEmpty()) {
+        if (StringsUtil.isEmpty(string)) {
             w.write("\"\"");
             return w;
         }
@@ -252,8 +252,7 @@ public abstract class JSONItem {
         writer.write("\"");
         writer.write(MIME_BIN_BASE64);
         try{
-            Base64.Encoder encoder = Base64.getUrlEncoder();
-            String base64 = encoder.encodeToString(bytes);
+            String base64 = android.Base64.encodeToString(bytes, 0);
             writer.write(base64);
         }catch (IOException exception){
             throw exception;

--- a/src/main/java/com/reandroid/json/JSONObject.java
+++ b/src/main/java/com/reandroid/json/JSONObject.java
@@ -6,6 +6,8 @@
 package com.reandroid.json;
 
 import com.reandroid.common.FileChannelInputStream;
+import com.reandroid.utils.StringsUtil;
+import com.reandroid.utils.collection.CollectionUtil;
 
 import java.io.*;
 
@@ -183,7 +185,7 @@ public class JSONObject extends JSONItem {
         LinkedHashMap<String, Object> copy = new LinkedHashMap<>(map);
         map.clear();
         List<String> sortedKeys = new ArrayList<>(copy.keySet());
-        sortedKeys.sort(keyComparator);
+        java.util.Collections.sort(sortedKeys, keyComparator);
         for(String key : sortedKeys){
             map.put(key, copy.get(key));
         }
@@ -704,7 +706,7 @@ public class JSONObject extends JSONItem {
                     && method.getReturnType() != Void.TYPE
                     && isValidMethodName(method.getName())) {
                 final String key = getKeyNameFromMethod(method);
-                if (key != null && !key.isEmpty()) {
+                if (!StringsUtil.isEmpty(key)) {
                     try {
                         final Object result = method.invoke(bean);
                         if (result != null) {
@@ -743,7 +745,7 @@ public class JSONObject extends JSONItem {
             }
         }
         JSONPropertyName annotation = getAnnotation(method, JSONPropertyName.class);
-        if (annotation != null && annotation.value() != null && !annotation.value().isEmpty()) {
+        if (annotation != null && !StringsUtil.isEmpty(annotation.value())) {
             return annotation.value();
         }
         String key;
@@ -762,9 +764,9 @@ public class JSONObject extends JSONItem {
             return null;
         }
         if (key.length() == 1) {
-            key = key.toLowerCase(Locale.ROOT);
+            key = StringsUtil.toLowerCaseWithLocale(key);
         } else if (!Character.isUpperCase(key.charAt(1))) {
-            key = key.substring(0, 1).toLowerCase(Locale.ROOT) + key.substring(1);
+            key =  StringsUtil.toLowerCaseWithLocale(key.substring(0, 1)) + key.substring(1);
         }
         return key;
     }

--- a/src/main/java/com/reandroid/json/JSONPointer.java
+++ b/src/main/java/com/reandroid/json/JSONPointer.java
@@ -53,7 +53,7 @@ public class JSONPointer {
         if (pointer == null) {
             throw new NullPointerException("pointer cannot be null");
         }
-        if (pointer.isEmpty() || pointer.equals("#")) {
+        if (pointer.length() == 0 || pointer.equals("#")) {
             this.refTokens = Collections.emptyList();
             return;
         }

--- a/src/main/java/com/reandroid/json/JsonUtil.java
+++ b/src/main/java/com/reandroid/json/JsonUtil.java
@@ -6,8 +6,6 @@
 package com.reandroid.json;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 
 public class JsonUtil {
 
@@ -17,7 +15,7 @@ public class JsonUtil {
         }
         text = text.substring(JSONItem.MIME_BIN_BASE64.length());
         try{
-            return Base64.getUrlDecoder().decode(text);
+            return android.Base64.decode(text, 0);
         }catch (Throwable throwable){
             throw new JSONException(throwable);
         }
@@ -28,7 +26,7 @@ public class JsonUtil {
         inputStream.close();
     }
     public static void readJSONObject(InputStream inputStream, JSONConvert<JSONObject> jsonConvert){
-        InputStreamReader reader=new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+        InputStreamReader reader=new InputStreamReader(inputStream, com.reandroid.utils.StringsUtil.UTF_8);
         readJSONObject(reader, jsonConvert);
     }
     public static void readJSONObject(Reader reader, JSONConvert<JSONObject> jsonConvert){
@@ -42,7 +40,7 @@ public class JsonUtil {
         inputStream.close();
     }
     public static void readJSONArray(InputStream inputStream, JSONConvert<JSONArray> jsonConvert){
-        InputStreamReader reader=new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+        InputStreamReader reader=new InputStreamReader(inputStream, com.reandroid.utils.StringsUtil.UTF_8);
         readJSONArray(reader, jsonConvert);
     }
     public static void readJSONArray(Reader reader, JSONConvert<JSONArray> jsonConvert){

--- a/src/main/java/com/reandroid/json/XMLTokener.java
+++ b/src/main/java/com/reandroid/json/XMLTokener.java
@@ -5,6 +5,8 @@
 */
 package com.reandroid.json;
 
+import com.reandroid.utils.StringsUtil;
+
 import java.io.Reader;
 
 public class XMLTokener extends JSONTokener {
@@ -95,7 +97,7 @@ public class XMLTokener extends JSONTokener {
 
     static String unescapeEntity(String e) {
         // validate
-        if (e == null || e.isEmpty()) {
+        if (StringsUtil.isEmpty(e)) {
             return "";
         }
         // if our entity is an encoded unicode point, parse it.

--- a/src/main/java/com/reandroid/utils/CompareUtil.java
+++ b/src/main/java/com/reandroid/utils/CompareUtil.java
@@ -16,12 +16,12 @@
 package com.reandroid.utils;
 
 import java.util.Comparator;
-import java.util.function.Function;
+import org.apache.commons.collections4.Transformer;
 
 public class CompareUtil {
 
-    public static<T, E extends Comparable<E>> Comparator<T> computeComparator(Function<? super T, E> function) {
-        return (t1, t2) -> compare(function.apply(t1), function.apply(t2));
+    public static<T, E extends Comparable<E>> Comparator<T> computeComparator(Transformer<? super T, E> function) {
+        return (t1, t2) -> compare(function.transformer(t1), function.transformer(t2));
     }
     public static<T extends Comparable<? super T>> int compare(T[] items1, T[] items2) {
         if(items1 == items2){

--- a/src/main/java/com/reandroid/utils/StringsUtil.java
+++ b/src/main/java/com/reandroid/utils/StringsUtil.java
@@ -16,10 +16,15 @@
 package com.reandroid.utils;
 
 import com.reandroid.utils.collection.ArrayIterator;
+import com.reandroid.utils.collection.CollectionUtil;
 
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 
 public class StringsUtil {
 
@@ -33,7 +38,18 @@ public class StringsUtil {
         }
         return results;
     }
-    public static boolean isDigits(String text){
+    
+    public final static Charset UTF_8 = Charset.forName("UTF-8");
+    public final static Charset UTF_16LE = Charset.forName("UTF-16LE");
+
+    public static byte[] getBytesOfString(String text, String charset) {
+        try {
+            return text.getBytes(charset);
+        } catch (UnsupportedEncodingException e) {
+            return text.getBytes(); // It should never happen
+        }
+    }
+     public static boolean isDigits(String text){
         if(isEmpty(text)){
             return false;
         }
@@ -456,6 +472,7 @@ public class StringsUtil {
         }
         return text;
     }
+
     public static boolean isEmpty(String text){
         return text == null || text.length() == 0;
     }
@@ -469,6 +486,21 @@ public class StringsUtil {
             }
         }
         return true;
+    }
+    public static String toUpperCaseWithLocale(String str) {
+        try {
+            return str.toUpperCase(Locale.ROOT);
+        } catch (Exception e) {
+            return str.toUpperCase();
+        }
+    }
+
+    public static String toLowerCaseWithLocale(String str) {
+        try {
+            return str.toLowerCase(Locale.ROOT);
+        } catch (Exception e) {
+            return str.toLowerCase();
+        }
     }
     public static String trimASCII(String text) {
         if (text == null) {
@@ -503,7 +535,7 @@ public class StringsUtil {
         return text.substring(0, end);
     }
     public static String toUpperCase(String str){
-        if(str == null || str.length() == 0){
+        if(isEmpty(str)){
             return str;
         }
         char[] chars = str.toCharArray();
@@ -557,7 +589,7 @@ public class StringsUtil {
         if(itemList == null || itemList.size() < 2){
             return;
         }
-        itemList.sort(CompareUtil.getToStringComparator());
+        Collections.sort(itemList, CompareUtil.getToStringComparator());
     }
     public static String formatNumber(long number, long maximumValue){
         int minLength = Long.toString(maximumValue).length();

--- a/src/main/java/com/reandroid/utils/collection/ArrayCollection.java
+++ b/src/main/java/com/reandroid/utils/collection/ArrayCollection.java
@@ -19,7 +19,7 @@ import com.reandroid.common.ArraySupplier;
 import com.reandroid.utils.NumbersUtil;
 
 import java.util.*;
-import java.util.function.Predicate;
+
 
 @SuppressWarnings("unchecked")
 public class ArrayCollection<T> implements ArraySupplier<T>, List<T>, Set<T>, Swappable {
@@ -86,7 +86,7 @@ public class ArrayCollection<T> implements ArraySupplier<T>, List<T>, Set<T>, Sw
     public ArrayCollection<T> copy(){
         return new ArrayCollection<>(toArray().clone());
     }
-    public ArrayCollection<T> filter(Predicate<? super T> filter){
+    public ArrayCollection<T> filter(org.apache.commons.collections4.Predicate<? super T> filter){
         int count = count(filter);
         if(count == size()){
             return this;
@@ -104,17 +104,17 @@ public class ArrayCollection<T> implements ArraySupplier<T>, List<T>, Set<T>, Sw
         collection.addAll(this.iterator(instance));
         return collection;
     }
-    public int count(Predicate<? super T> filter){
+    public int count(org.apache.commons.collections4.Predicate<? super T> filter){
         return count(filter, size());
     }
-    public int count(Predicate<? super T> filter, int limit){
+    public int count(org.apache.commons.collections4.Predicate<? super T> filter, int limit){
         int result = 0;
         int size = size();
         for(int i = 0; i < size; i++){
             if(result >= limit){
                 break;
             }
-            if(filter.test(get(i))){
+            if(filter.evaluate(get(i))){
                 result ++;
             }
         }
@@ -138,10 +138,10 @@ public class ArrayCollection<T> implements ArraySupplier<T>, List<T>, Set<T>, Sw
         }
         return result;
     }
-    public int countFromLast(Predicate<? super T> predicate){
+    public int countFromLast(org.apache.commons.collections4.Predicate<? super T> predicate){
         int result = 0;
         int i = this.size() - 1;
-        while (i >= 0 && predicate.test(get(i))) {
+        while (i >= 0 && predicate.evaluate(get(i))) {
             result ++;
             i --;
         }
@@ -218,10 +218,10 @@ public class ArrayCollection<T> implements ArraySupplier<T>, List<T>, Set<T>, Sw
         }
         return containsExact(obj) || containsEquals(obj);
     }
-    public boolean containsIf(Predicate<? super T> predicate) {
+    public boolean containsIf(org.apache.commons.collections4.Predicate<? super T> predicate) {
         return containsIf(0, predicate);
     }
-    public boolean containsIf(int start, Predicate<? super T> predicate) {
+    public boolean containsIf(int start, org.apache.commons.collections4.Predicate<? super T> predicate) {
         if(start < 0) {
             start = 0;
         }
@@ -231,7 +231,7 @@ public class ArrayCollection<T> implements ArraySupplier<T>, List<T>, Set<T>, Sw
         }
         Object[] elements = this.mElements;
         for(int i = start; i < size; i++){
-            if(predicate.test((T)elements[i])){
+            if(predicate.evaluate((T)elements[i])){
                 return true;
             }
         }
@@ -346,7 +346,7 @@ public class ArrayCollection<T> implements ArraySupplier<T>, List<T>, Set<T>, Sw
     public<T1> Iterator<T1> iterator(Class<T1> instance){
         return InstanceIterator.of(iterator(), instance);
     }
-    public Iterator<T> iterator(Predicate<? super T> filter){
+    public Iterator<T> iterator(org.apache.commons.collections4.Predicate<? super T> filter){
         return FilterIterator.of(iterator(), filter);
     }
     @Override
@@ -424,7 +424,11 @@ public class ArrayCollection<T> implements ArraySupplier<T>, List<T>, Set<T>, Sw
             arrayCopy(elements, out, length);
             return out;
         }
-        return (T1[]) Arrays.copyOf(elements, size, out.getClass());
+        T1[] newArray = (T1[]) java.lang.reflect.Array.newInstance(out.getClass().getComponentType(), size);
+        for (int i = 0; i < size; i++) {
+            newArray[i] = (T1) elements[i];
+        }
+        return newArray;
     }
     public <T1> T1[] toArrayFill(T1[] out) {
         Object[] elements = this.mElements;
@@ -444,7 +448,7 @@ public class ArrayCollection<T> implements ArraySupplier<T>, List<T>, Set<T>, Sw
         return result;
     }
 
-    public ArrayCollection<T> subListIf(Predicate<? super T> predicate) {
+    public ArrayCollection<T> subListIf(org.apache.commons.collections4.Predicate<? super T> predicate) {
         ArrayCollection<T> results = new ArrayCollection<>();
         results.addAll(this.iterator(predicate));
         return results;
@@ -585,10 +589,10 @@ public class ArrayCollection<T> implements ArraySupplier<T>, List<T>, Set<T>, Sw
         return result;
     }
 
-    public int indexOfIf(Predicate<? super T> predicate) {
+    public int indexOfIf(org.apache.commons.collections4.Predicate<? super T> predicate) {
         return indexOfIf(0, predicate);
     }
-    public int indexOfIf(int start, Predicate<? super T> predicate) {
+    public int indexOfIf(int start, org.apache.commons.collections4.Predicate<? super T> predicate) {
         if(start < 0) {
             start = 0;
         }
@@ -598,7 +602,7 @@ public class ArrayCollection<T> implements ArraySupplier<T>, List<T>, Set<T>, Sw
         }
         Object[] elements = this.mElements;
         for(int i = start; i < size; i++){
-            if(predicate.test((T)elements[i])){
+            if(predicate.evaluate((T)elements[i])){
                 return i;
             }
         }
@@ -730,8 +734,7 @@ public class ArrayCollection<T> implements ArraySupplier<T>, List<T>, Set<T>, Sw
         this.mElements = update;
         return true;
     }
-    @Override
-    public boolean removeIf(Predicate<? super T> filter){
+    public boolean removeIf(org.apache.commons.collections4.Predicate<? super T> filter){
         Object[] elements = this.mElements;
         if(elements == null){
             return false;
@@ -743,7 +746,7 @@ public class ArrayCollection<T> implements ArraySupplier<T>, List<T>, Set<T>, Sw
         int result = 0;
         for(int i = 0; i < length; i++){
             T item = (T)elements[i];
-            if(filter.test(item)) {
+            if(filter.evaluate(item)) {
                 elements[i] = null;
                 notifyRemoved(i, item);
                 result ++;
@@ -1036,9 +1039,7 @@ public class ArrayCollection<T> implements ArraySupplier<T>, List<T>, Set<T>, Sw
         return update;
     }
     private void arrayCopy(Object[] source, Object[] destination, int length){
-        for(int i = 0; i < length; i++){
-            destination[i] = source[i];
-        }
+        if (length >= 0) System.arraycopy(source, 0, destination, 0, length);
     }
     private Object[] getNewArray(Object[] source, int length){
         Object[] result = getNewArray(length);

--- a/src/main/java/com/reandroid/utils/collection/ArrayIterator.java
+++ b/src/main/java/com/reandroid/utils/collection/ArrayIterator.java
@@ -17,18 +17,18 @@ package com.reandroid.utils.collection;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.function.Predicate;
+
 
 public class ArrayIterator<T> implements Iterator<T>, SizedItem, SizedIterator{
 
     private final Object[] elements;
     private final int mStart;
     private final int mLength;
-    private final Predicate<? super T> mFilter;
+    private final org.apache.commons.collections4.Predicate<? super T> mFilter;
     private int index;
     private T mNext;
 
-    public ArrayIterator(Object[] elements, int start, int length, Predicate<? super T> filter){
+    public ArrayIterator(Object[] elements, int start, int length, org.apache.commons.collections4.Predicate<? super T> filter){
         this.elements = elements;
         this.mStart = start;
         this.mLength = length;
@@ -37,7 +37,7 @@ public class ArrayIterator<T> implements Iterator<T>, SizedItem, SizedIterator{
     public ArrayIterator(Object[] elements, int start, int length){
         this(elements, start, length, null);
     }
-    public ArrayIterator(Object[] elements, Predicate<? super T> filter){
+    public ArrayIterator(Object[] elements, org.apache.commons.collections4.Predicate<? super T> filter){
         this(elements, 0, elements.length, filter);
     }
     public ArrayIterator(Object[] elements){
@@ -85,7 +85,7 @@ public class ArrayIterator<T> implements Iterator<T>, SizedItem, SizedIterator{
         if(item == null){
             return false;
         }
-        return mFilter == null || mFilter.test(item);
+        return mFilter == null || mFilter.evaluate(item);
     }
     public static<T1> Iterator<T1> of(Object[] elements){
         if(isEmpty(elements)){
@@ -93,7 +93,7 @@ public class ArrayIterator<T> implements Iterator<T>, SizedItem, SizedIterator{
         }
         return new ArrayIterator<>(elements);
     }
-    public static<T1> Iterator<T1> of(Object[] elements, Predicate<? super T1> filter){
+    public static<T1> Iterator<T1> of(Object[] elements, org.apache.commons.collections4.Predicate<? super T1> filter){
         if(isEmpty(elements)){
             return EmptyIterator.of();
         }

--- a/src/main/java/com/reandroid/utils/collection/CollectionUtil.java
+++ b/src/main/java/com/reandroid/utils/collection/CollectionUtil.java
@@ -18,7 +18,7 @@ package com.reandroid.utils.collection;
 import com.reandroid.utils.ObjectsUtil;
 
 import java.util.*;
-import java.util.function.Predicate;
+
 
 public class CollectionUtil {
 
@@ -40,9 +40,7 @@ public class CollectionUtil {
         }
         int length = elements.length;
         HashSet<T> results = new HashSet<>(length);
-        for (int i = 0; i < length; i ++){
-            results.add(elements[i]);
-        }
+        Collections.addAll(results, elements);
         return results;
     }
     public static<T> HashSet<T> toHashSet(Iterator<? extends T> iterator) {
@@ -54,8 +52,18 @@ public class CollectionUtil {
         return results;
     }
 
+    public static<T extends Comparable<T>> void sort(List<T> list, Comparator comparator) {
+        Object[] a = list.toArray();
+        ArraySort.sort(a, comparator);
+        ListIterator<T> i = list.listIterator();
+        for (Object e : a) {
+            i.next();
+            i.set((T) e);
+        }
+    }
+
     public static<T extends Comparable<T>> void sort(List<T> list){
-        list.sort(getComparator());
+        sort(list, getComparator());
     }
     public static<T> T getLast(Iterator<T> iterator){
         if(iterator == null){
@@ -263,40 +271,40 @@ public class CollectionUtil {
         }
     }
     @SuppressWarnings("unchecked")
-    public static<T> Predicate<T> getAcceptAll(){
-        return (Predicate<T>) ACCEPT_ALL;
+    public static<T> org.apache.commons.collections4.Predicate<T> getAcceptAll(){
+        return (org.apache.commons.collections4.Predicate<T>) ACCEPT_ALL;
     }
     @SuppressWarnings("unchecked")
-    public static<T> Predicate<T> getRejectAll(){
-        return (Predicate<T>) REJECT_ALL;
+    public static<T> org.apache.commons.collections4.Predicate<T> getRejectAll(){
+        return (org.apache.commons.collections4.Predicate<T>) REJECT_ALL;
     }
 
-    public static<T> Predicate<? super T> orFilter(Predicate<? super T> filter1, Predicate<? super T> filter2){
+    public static<T> org.apache.commons.collections4.Predicate<? super T> orFilter(org.apache.commons.collections4.Predicate<? super T> filter1, org.apache.commons.collections4.Predicate<? super T> filter2){
         if(filter1 == null || filter1 == getRejectAll()){
             return filter2;
         }
         if(filter2 == null || filter2 == getRejectAll()){
             return filter1;
         }
-        return t -> (filter1.test(t) || filter2.test(t));
+        return t -> (filter1.evaluate(t) || filter2.evaluate(t));
     }
-    public static<T> Predicate<T> andFilter(Predicate<T> filter1, Predicate<T> filter2){
+    public static<T> org.apache.commons.collections4.Predicate<T> andFilter(org.apache.commons.collections4.Predicate<T> filter1, org.apache.commons.collections4.Predicate<T> filter2){
         if(filter1 == null || filter1 == getAcceptAll()){
             return filter2;
         }
         if(filter2 == null || filter2 == getAcceptAll()){
             return filter1;
         }
-        return t -> (filter1.test(t) && filter2.test(t));
+        return t -> (filter1.evaluate(t) && filter2.evaluate(t));
     }
-    public static<T> Predicate<T> negateFilter(Predicate<T> filter){
-        return t -> !filter.test(t);
+    public static<T> org.apache.commons.collections4.Predicate<T> negateFilter(org.apache.commons.collections4.Predicate<T> filter){
+        return t -> !filter.evaluate(t);
     }
-    public static<T> Predicate<T> diffFilter(Predicate<T> filter1, Predicate<T> filter2){
-        return t -> (filter1.test(t) != filter2.test(t));
+    public static<T> org.apache.commons.collections4.Predicate<T> diffFilter(org.apache.commons.collections4.Predicate<T> filter1, org.apache.commons.collections4.Predicate<T> filter2){
+        return t -> (filter1.evaluate(t) != filter2.evaluate(t));
     }
-    public static<T> Predicate<T> equalFilter(Predicate<T> filter1, Predicate<T> filter2){
-        return t -> (filter1.test(t) == filter2.test(t));
+    public static<T> org.apache.commons.collections4.Predicate<T> equalFilter(org.apache.commons.collections4.Predicate<T> filter1, org.apache.commons.collections4.Predicate<T> filter2){
+        return t -> (filter1.evaluate(t) == filter2.evaluate(t));
     }
     @SuppressWarnings("unchecked")
     public static<T extends Comparable<T>> Comparator<T> getComparator(){
@@ -310,6 +318,6 @@ public class CollectionUtil {
         }
     };
 
-    private static final Predicate<?> ACCEPT_ALL = (Predicate<Object>) o -> true;
-    private static final Predicate<?> REJECT_ALL = (Predicate<Object>) o -> false;
+    private static final org.apache.commons.collections4.Predicate<?> ACCEPT_ALL = (org.apache.commons.collections4.Predicate<Object>) o -> true;
+    private static final org.apache.commons.collections4.Predicate<?> REJECT_ALL = (org.apache.commons.collections4.Predicate<Object>) o -> false;
 }

--- a/src/main/java/com/reandroid/utils/collection/ComputeCollection.java
+++ b/src/main/java/com/reandroid/utils/collection/ComputeCollection.java
@@ -18,20 +18,20 @@ package com.reandroid.utils.collection;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Objects;
-import java.util.function.Function;
+import org.apache.commons.collections4.Transformer;
 
 public class ComputeCollection<T, E> implements Collection<T> {
 
     private final Collection<? extends E> source;
-    private final Function<? super E, T> function;
+    private final Transformer<? super E, T> function;
 
-    public ComputeCollection(Collection<? extends E> collection, Function<? super E, T> function){
+    public ComputeCollection(Collection<? extends E> collection, Transformer<? super E, T> function){
         this.source = collection;
         this.function = function;
     }
 
     public T apply(E input){
-        return function.apply(input);
+        return function.transformer(input);
     }
     public Collection<? extends E> getSource() {
         return source;
@@ -67,7 +67,7 @@ public class ComputeCollection<T, E> implements Collection<T> {
         Iterator<? extends E> iterator = source.iterator();
         int i = 0;
         while (iterator.hasNext()){
-            results[i] = function.apply(iterator.next());
+            results[i] = function.transformer(iterator.next());
             i++;
         }
         return results;
@@ -89,7 +89,7 @@ public class ComputeCollection<T, E> implements Collection<T> {
         Iterator<? extends E> iterator = source.iterator();
         int i = 0;
         while (i < size && iterator.hasNext()){
-            out[i] = (T1) function.apply(iterator.next());
+            out[i] = (T1) function.transformer(iterator.next());
             i++;
         }
         return out;

--- a/src/main/java/com/reandroid/utils/collection/ComputeIterator.java
+++ b/src/main/java/com/reandroid/utils/collection/ComputeIterator.java
@@ -17,20 +17,20 @@ package com.reandroid.utils.collection;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.function.Function;
-import java.util.function.Predicate;
+import org.apache.commons.collections4.Transformer;
+
 
 public class ComputeIterator<E, T> implements Iterator<T> {
     private final Iterator<? extends E> iterator;
-    private final Function<? super E, T> function;
-    private final Predicate<T> filter;
+    private final Transformer<? super E, T> function;
+    private final org.apache.commons.collections4.Predicate<T> filter;
     private T mNext;
-    public ComputeIterator(Iterator<? extends E> iterator, Function<? super E, T> function, Predicate<T> filter){
+    public ComputeIterator(Iterator<? extends E> iterator, Transformer<? super E, T> function, org.apache.commons.collections4.Predicate<T> filter){
         this.iterator = iterator;
         this.function = function;
         this.filter = filter;
     }
-    public ComputeIterator(Iterator<? extends E> iterator, Function<? super E, T> function){
+    public ComputeIterator(Iterator<? extends E> iterator, Transformer<? super E, T> function){
         this(iterator, function, null);
     }
     @Override
@@ -49,9 +49,9 @@ public class ComputeIterator<E, T> implements Iterator<T> {
     private T getNext(){
         if(mNext == null) {
             while (iterator.hasNext()) {
-                T output = function.apply(iterator.next());
+                T output = function.transformer(iterator.next());
                 if (output != null) {
-                    if(filter == null || filter.test(output)){
+                    if(filter == null || filter.evaluate(output)){
                         mNext = output;
                         break;
                     }
@@ -60,7 +60,7 @@ public class ComputeIterator<E, T> implements Iterator<T> {
         }
         return mNext;
     }
-    public static<E1, T1> Iterator<T1> of(Iterator<? extends E1> iterator, Function<? super E1, T1> function){
+    public static<E1, T1> Iterator<T1> of(Iterator<? extends E1> iterator, Transformer<? super E1, T1> function){
         if(!iterator.hasNext()){
             return EmptyIterator.of();
         }

--- a/src/main/java/com/reandroid/utils/collection/ComputeList.java
+++ b/src/main/java/com/reandroid/utils/collection/ComputeList.java
@@ -16,11 +16,11 @@
 package com.reandroid.utils.collection;
 
 import java.util.*;
-import java.util.function.Function;
+import org.apache.commons.collections4.Transformer;
 
 public class ComputeList<T, E> extends ComputeCollection<T, E> implements List<T>{
 
-    public ComputeList(List<? extends E> list, Function<? super E, T> function) {
+    public ComputeList(List<? extends E> list, Transformer<? super E, T> function) {
         super(list, function);
     }
 

--- a/src/main/java/com/reandroid/utils/collection/FilterIterator.java
+++ b/src/main/java/com/reandroid/utils/collection/FilterIterator.java
@@ -17,16 +17,16 @@ package com.reandroid.utils.collection;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.function.Predicate;
 
-public class FilterIterator<T> implements Iterator<T>, Predicate<T> {
+
+public class FilterIterator<T> implements Iterator<T>, org.apache.commons.collections4.Predicate<T> {
 
     private final Iterator<? extends T> iterator;
     private T mNext;
-    private final Predicate<? super T> mFilter;
+    private final org.apache.commons.collections4.Predicate<? super T> mFilter;
     private boolean mFinished;
 
-    public FilterIterator(Iterator<? extends T> iterator, Predicate<? super T> filter){
+    public FilterIterator(Iterator<? extends T> iterator, org.apache.commons.collections4.Predicate<? super T> filter){
         this.iterator = iterator;
         this.mFilter = filter;
     }
@@ -35,7 +35,7 @@ public class FilterIterator<T> implements Iterator<T>, Predicate<T> {
     }
 
     @Override
-    public boolean test(T item){
+    public boolean evaluate(T item){
         return item != null;
     }
 
@@ -75,11 +75,11 @@ public class FilterIterator<T> implements Iterator<T>, Predicate<T> {
         return mNext;
     }
     private boolean testAll(T item){
-        if(item == null || !test(item)){
+        if(item == null || !evaluate(item)){
             return false;
         }
         return mFilter == null
-                || mFilter.test(item);
+                || mFilter.evaluate(item);
     }
 
     public static final class Except<T1> extends FilterIterator<T1>{
@@ -96,7 +96,7 @@ public class FilterIterator<T> implements Iterator<T>, Predicate<T> {
         }
 
         @Override
-        public boolean test(T1 item){
+        public boolean evaluate(T1 item){
             if(item == null || item == excludeItem){
                 return false;
             }
@@ -106,7 +106,7 @@ public class FilterIterator<T> implements Iterator<T>, Predicate<T> {
             return item.equals(excludeItem);
         }
     }
-    public static<T1> Iterator<T1> of(Iterator<? extends T1> iterator,  Predicate<? super T1> filter){
+    public static<T1> Iterator<T1> of(Iterator<? extends T1> iterator,  org.apache.commons.collections4.Predicate<? super T1> filter){
         if(iterator == null || !iterator.hasNext()){
             return EmptyIterator.of();
         }

--- a/src/main/java/com/reandroid/utils/collection/GroupMap.java
+++ b/src/main/java/com/reandroid/utils/collection/GroupMap.java
@@ -19,7 +19,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.function.Function;
+import org.apache.commons.collections4.Transformer;
 
 public class GroupMap<K, V> {
 
@@ -99,13 +99,13 @@ public class GroupMap<K, V> {
         return (V) obj;
     }
 
-    public void putAll(Collection<? extends V> collection, Function<? super V, K> function){
+    public void putAll(Collection<? extends V> collection, Transformer<? super V, K> function){
         if(collection.isEmpty()){
             return;
         }
         initializeEmpty(collection.size());
         for(V value : collection){
-            put(function.apply(value), value);
+            put(function.transformer(value), value);
         }
     }
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/reandroid/utils/collection/IndexIterator.java
+++ b/src/main/java/com/reandroid/utils/collection/IndexIterator.java
@@ -17,14 +17,14 @@ package com.reandroid.utils.collection;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.function.Predicate;
+
 
 public class IndexIterator<T> implements Iterator<T> {
-    private final Predicate<? super T> mFilter;
+    private final org.apache.commons.collections4.Predicate<? super T> mFilter;
     private final SizedSupplier<? extends T> mSupplier;
     private int mIndex;
     private T mNext;
-    public IndexIterator(SizedSupplier<? extends T> supplier, Predicate<? super T> filter){
+    public IndexIterator(SizedSupplier<? extends T> supplier, org.apache.commons.collections4.Predicate<? super T> filter){
         this.mSupplier = supplier;
         this.mFilter = filter;
     }
@@ -63,13 +63,13 @@ public class IndexIterator<T> implements Iterator<T> {
             return false;
         }
         return mFilter == null
-                || mFilter.test(item);
+                || mFilter.evaluate(item);
     }
 
     public static<T1> Iterator<T1> of(SizedSupplier<T1> supplier){
         return of(supplier, null);
     }
-    public static<T1> Iterator<T1> of(SizedSupplier<T1> supplier, Predicate<? super T1> filter){
+    public static<T1> Iterator<T1> of(SizedSupplier<T1> supplier, org.apache.commons.collections4.Predicate<? super T1> filter){
         if(supplier == null || supplier.size() == 0){
             return EmptyIterator.of();
         }

--- a/src/main/java/com/reandroid/utils/collection/InstanceIterator.java
+++ b/src/main/java/com/reandroid/utils/collection/InstanceIterator.java
@@ -17,15 +17,15 @@ package com.reandroid.utils.collection;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.function.Predicate;
+
 
 public class InstanceIterator<T> implements Iterator<T> {
     private final Iterator<?> iterator;
     private final Class<T> instance;
-    private final Predicate<? super T> filter;
+    private final org.apache.commons.collections4.Predicate<? super T> filter;
     private T mCurrent;
 
-    public InstanceIterator(Iterator<?> iterator, Class<T> instance, Predicate<? super T> filter){
+    public InstanceIterator(Iterator<?> iterator, Class<T> instance, org.apache.commons.collections4.Predicate<? super T> filter){
         this.iterator = iterator;
         this.instance = instance;
         this.filter = filter;
@@ -57,7 +57,7 @@ public class InstanceIterator<T> implements Iterator<T> {
         }
         Iterator<?> iterator = this.iterator;
         Class<T> instance = this.instance;
-        Predicate<? super T> filter = this.filter;
+        org.apache.commons.collections4.Predicate<? super T> filter = this.filter;
         while (iterator.hasNext()){
             Object obj = iterator.next();
             if(obj == null){
@@ -65,7 +65,7 @@ public class InstanceIterator<T> implements Iterator<T> {
             }
             if(instance.isInstance(obj)){
                 current = (T)obj;
-                if(filter == null || filter.test(current)){
+                if(filter == null || filter.evaluate(current)){
                     mCurrent = current;
                     return current;
                 }
@@ -80,7 +80,7 @@ public class InstanceIterator<T> implements Iterator<T> {
         }
         return new InstanceIterator<>(iterator, instance);
     }
-    public static<T1> Iterator<T1> of(Iterator<?> iterator, Class<T1> instance, Predicate<? super T1> filter){
+    public static<T1> Iterator<T1> of(Iterator<?> iterator, Class<T1> instance, org.apache.commons.collections4.Predicate<? super T1> filter){
         if(!iterator.hasNext()){
             return EmptyIterator.of();
         }

--- a/src/main/java/com/reandroid/utils/collection/RecursiveIterator.java
+++ b/src/main/java/com/reandroid/utils/collection/RecursiveIterator.java
@@ -17,26 +17,26 @@ package com.reandroid.utils.collection;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.function.Function;
-import java.util.function.Predicate;
+import org.apache.commons.collections4.Transformer;
+
 
 public class RecursiveIterator<T> implements Iterator<T> {
 
     private T item;
-    private final Function<T, Iterator<? extends T>> function;
-    private final Predicate<? super T> filter;
+    private final Transformer<T, Iterator<? extends T>> function;
+    private final org.apache.commons.collections4.Predicate<? super T> filter;
 
     private boolean firstProcessed;
     private T current;
     private Iterator<? extends T> currentIterator;
     private RecursiveIterator<T> currentRecursiveIterator;
 
-    public RecursiveIterator(T item, Function<T, Iterator<? extends T>> function, Predicate<? super T> filter){
+    public RecursiveIterator(T item, Transformer<T, Iterator<? extends T>> function, org.apache.commons.collections4.Predicate<? super T> filter){
         this.item = item;
         this.function = function;
         this.filter = filter;
     }
-    public RecursiveIterator(T item, Function<T, Iterator<? extends T>> function){
+    public RecursiveIterator(T item, Transformer<T, Iterator<? extends T>> function){
         this(item, function, null);
     }
 
@@ -109,7 +109,7 @@ public class RecursiveIterator<T> implements Iterator<T> {
         if(element == null){
             iterator = null;
         }else {
-            iterator = function.apply(element);
+            iterator = function.transformer(element);
         }
         this.currentIterator = iterator;
     }
@@ -118,26 +118,26 @@ public class RecursiveIterator<T> implements Iterator<T> {
         if(element == null){
             return false;
         }
-        Predicate<? super T> filter = this.filter;
-        return filter == null || filter.test(element);
+        org.apache.commons.collections4.Predicate<? super T> filter = this.filter;
+        return filter == null || filter.evaluate(element);
     }
 
-    public static<T1> Iterator<T1> of(T1 item, Function<T1, Iterator<? extends T1>> function, Predicate<? super T1> filter){
+    public static<T1> Iterator<T1> of(T1 item, Transformer<T1, Iterator<? extends T1>> function, org.apache.commons.collections4.Predicate<? super T1> filter){
         return new RecursiveIterator<>(item, function, filter);
     }
-    public static<T1> Iterator<T1> of(T1 item, Function<T1, Iterator<? extends T1>> function){
+    public static<T1> Iterator<T1> of(T1 item, Transformer<T1, Iterator<? extends T1>> function){
         return new RecursiveIterator<>(item, function);
     }
 
-    public static<T1, E> Iterator<E> compute(T1 item, Function<T1, Iterator<? extends T1>> function, Function<T1, Iterator<? extends E>> computer){
+    public static<T1, E> Iterator<E> compute(T1 item, Transformer<T1, Iterator<? extends T1>> function, Transformer<T1, Iterator<? extends E>> computer){
         return compute(item, function, null, computer);
     }
     @SuppressWarnings("unchecked")
-    public static<T1, E> Iterator<E> compute(T1 item, Function<T1, Iterator<? extends T1>> function, Predicate<? super T1> filter, Function<T1, Iterator<? extends E>> computer){
+    public static<T1, E> Iterator<E> compute(T1 item, Transformer<T1, Iterator<? extends T1>> function, org.apache.commons.collections4.Predicate<? super T1> filter, Transformer<T1, Iterator<? extends E>> computer){
         return new IterableIterator<T1, E>(new RecursiveIterator<>(item, function, filter)) {
             @Override
             public Iterator<E> iterator(T1 element) {
-                return (Iterator<E>) computer.apply(element);
+                return (Iterator<E>) computer.transformer(element);
             }
         };
     }

--- a/src/main/java/com/reandroid/utils/collection/UniqueIterator.java
+++ b/src/main/java/com/reandroid/utils/collection/UniqueIterator.java
@@ -18,13 +18,13 @@ package com.reandroid.utils.collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.function.Predicate;
+
 
 public class UniqueIterator<T> extends FilterIterator<T> {
 
     private Set<T> excludeSet;
 
-    public UniqueIterator(Iterator<T> iterator, Predicate<? super T> filter){
+    public UniqueIterator(Iterator<T> iterator, org.apache.commons.collections4.Predicate<? super T> filter){
         super(iterator, filter);
     }
     public UniqueIterator(Iterator<T> iterator){
@@ -54,7 +54,7 @@ public class UniqueIterator<T> extends FilterIterator<T> {
     }
 
     @Override
-    public boolean test(T item) {
+    public boolean evaluate(T item) {
         if(item == null){
             return false;
         }

--- a/src/main/java/com/reandroid/utils/io/FileIterator.java
+++ b/src/main/java/com/reandroid/utils/io/FileIterator.java
@@ -22,19 +22,19 @@ import com.reandroid.utils.collection.CollectionUtil;
 import java.io.File;
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public class FileIterator implements Iterator<File> {
 
     private final File file;
-    private final Predicate<File> filter;
+    private final org.apache.commons.collections4.Predicate<File> filter;
     private final Comparator<File> comparator;
     private final File[] files;
     private int index;
     private File currentFile;
     private FileIterator currentIterator;
 
-    public FileIterator(File file, Predicate<File> filter, Comparator<File> comparator) {
+    public FileIterator(File file, org.apache.commons.collections4.Predicate<File> filter, Comparator<File> comparator) {
         this.file = file;
         this.filter = filter;
         this.comparator = comparator;
@@ -50,7 +50,7 @@ public class FileIterator implements Iterator<File> {
         this.files = files;
         this.index = -2;
     }
-    public FileIterator(File file, Predicate<File> filter) {
+    public FileIterator(File file, org.apache.commons.collections4.Predicate<File> filter) {
         this(file, filter, null);
     }
     public FileIterator(File file, Comparator<File> comparator) {
@@ -123,7 +123,7 @@ public class FileIterator implements Iterator<File> {
         if(!file.isFile()){
             return false;
         }
-        return filter == null || filter.test(file);
+        return filter == null || filter.evaluate(file);
     }
 
     public static final Comparator<File> NAME_COMPARATOR = (file1, file2) -> {
@@ -138,7 +138,7 @@ public class FileIterator implements Iterator<File> {
         return StringsUtil.toUpperCase(file1.getName())
                 .compareTo(StringsUtil.toUpperCase(file2.getName()));
     };
-    public static Predicate<File> getExtensionFilter(String extension){
+    public static org.apache.commons.collections4.Predicate<File> getExtensionFilter(String extension){
         if(extension == null){
             return CollectionUtil.getAcceptAll();
         }

--- a/src/main/java/com/reandroid/utils/io/FilePermissions.java
+++ b/src/main/java/com/reandroid/utils/io/FilePermissions.java
@@ -25,26 +25,30 @@ public class FilePermissions {
     }
 
     public boolean apply(File file) {
+        try {
+            File.class.getMethod("setExecutable", boolean.class);
+            Permission owner = owner();
+            Permission group = group();
+            Permission others = others();
+            boolean result;
 
-        Permission owner = owner();
-        Permission group = group();
-        Permission others = others();
-        boolean result;
+            boolean applied = file.setExecutable(owner.execute(),
+                    owner.execute() && !group.execute() && !others.execute());
+            result = applied;
 
-        boolean applied = file.setExecutable(owner.execute(),
-                owner.execute() && !group.execute() && !others.execute());
-        result = applied;
+            applied = file.setWritable(owner.write(),
+                    owner.write() && !group.write() && !others.write());
 
-        applied = file.setWritable(owner.write(),
-                owner.write() && !group.write() && !others.write());
+            result |= applied;
+            applied = file.setReadable(owner.read(),
+                    owner.read() && !group.read() && !others.read());
 
-        result |= applied;
-        applied = file.setReadable(owner.read(),
-                owner.read() && !group.read() && !others.read());
+            result |= applied;
 
-        result |= applied;
-
-        return result;
+            return result;
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
     }
     public int get() {
         return value;

--- a/src/main/java/com/reandroid/utils/io/IOUtil.java
+++ b/src/main/java/com/reandroid/utils/io/IOUtil.java
@@ -16,18 +16,18 @@
 package com.reandroid.utils.io;
 
 import com.reandroid.common.FileChannelInputStream;
+import com.reandroid.utils.StringsUtil;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 
 @SuppressWarnings({"ResultOfMethodCallIgnored"})
 public class IOUtil {
 
     public static String readUtf8(File file) throws IOException {
-        return new String(readFully(file), StandardCharsets.UTF_8);
+        return new String(readFully(file), com.reandroid.utils.StringsUtil.UTF_8);
     }
     public static String readUtf8(InputStream inputStream) throws IOException {
-        return new String(readFully(inputStream), StandardCharsets.UTF_8);
+        return new String(readFully(inputStream), com.reandroid.utils.StringsUtil.UTF_8);
     }
     public static void writeUtf8(String content, File file) throws IOException {
         File tmp = file;
@@ -41,7 +41,7 @@ public class IOUtil {
         }
     }
     public static void writeUtf8(String content, OutputStream outputStream) throws IOException {
-        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+        byte[] bytes = StringsUtil.getBytesOfString(content, "UTF-8");
         outputStream.write(bytes, 0, bytes.length);
         outputStream.close();
     }

--- a/src/main/java/com/reandroid/xml/StyleSpanEventSet.java
+++ b/src/main/java/com/reandroid/xml/StyleSpanEventSet.java
@@ -17,6 +17,8 @@ package com.reandroid.xml;
 
 import com.reandroid.utils.CompareUtil;
 import com.reandroid.utils.collection.ArrayCollection;
+import com.reandroid.utils.collection.CollectionUtil;
+
 import org.xmlpull.v1.XmlSerializer;
 
 import java.io.IOException;
@@ -48,7 +50,7 @@ public class StyleSpanEventSet {
     }
     private List<StyleSpanEvent> getEventList() {
         List<StyleSpanEvent> eventList = this.eventList;
-        eventList.sort(CompareUtil.getComparableComparator());
+        java.util.Collections.sort(eventList, CompareUtil.getComparableComparator());
         return eventList;
     }
 

--- a/src/main/java/com/reandroid/xml/XMLElement.java
+++ b/src/main/java/com/reandroid/xml/XMLElement.java
@@ -29,7 +29,7 @@ import org.xmlpull.v1.XmlSerializer;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.*;
-import java.util.function.Predicate;
+
 
 public class XMLElement extends XMLNodeTree implements Element<XMLNode> {
 
@@ -232,7 +232,7 @@ public class XMLElement extends XMLNodeTree implements Element<XMLNode> {
     public Iterator<? extends XMLElement> getElements(){
         return iterator(XMLElement.class);
     }
-    public Iterator<XMLElement> getElements(Predicate<XMLElement> filter){
+    public Iterator<XMLElement> getElements(org.apache.commons.collections4.Predicate<XMLElement> filter){
         return iterator(XMLElement.class, filter);
     }
     public Iterator<XMLElement> getElements(String name){

--- a/src/main/java/com/reandroid/xml/XMLFactory.java
+++ b/src/main/java/com/reandroid/xml/XMLFactory.java
@@ -37,7 +37,7 @@ public class XMLFactory {
     public static XmlPullParser newPullParser(File file) throws XmlPullParserException {
         XmlPullParser parser = newPullParser();
         try {
-            parser.setInput(new FileChannelInputStream(file), StandardCharsets.UTF_8.name());
+            parser.setInput(new FileChannelInputStream(file), com.reandroid.utils.StringsUtil.UTF_8.name());
         } catch (IOException ex) {
             throw new XmlPullParserException(ex.getMessage());
         }
@@ -50,7 +50,7 @@ public class XMLFactory {
     }
     public static XmlPullParser newPullParser(InputStream inputStream) throws XmlPullParserException {
         XmlPullParser parser = newPullParser();
-        parser.setInput(inputStream, StandardCharsets.UTF_8.name());
+        parser.setInput(inputStream, com.reandroid.utils.StringsUtil.UTF_8.name());
         return parser;
     }
     public static XmlPullParser newPullParser(){
@@ -72,7 +72,7 @@ public class XMLFactory {
     }
     public static XmlSerializer newSerializer(OutputStream outputStream) throws IOException{
         XmlSerializer serializer = newSerializer();
-        serializer.setOutput(outputStream, StandardCharsets.UTF_8.name());
+        serializer.setOutput(outputStream, com.reandroid.utils.StringsUtil.UTF_8.name());
         return serializer;
     }
     public static XmlSerializer newSerializer(){

--- a/src/main/java/com/reandroid/xml/XMLNodeTree.java
+++ b/src/main/java/com/reandroid/xml/XMLNodeTree.java
@@ -22,7 +22,7 @@ import org.xmlpull.v1.XmlSerializer;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public abstract class XMLNodeTree extends XMLNode implements
         NodeTree<XMLNode>, Iterable<XMLNode>, SizedSupplier<XMLNode> {
@@ -54,7 +54,7 @@ public abstract class XMLNodeTree extends XMLNode implements
             lastTrimSize = 0;
         }
     }
-    public Iterator<XMLNode> iterator(Predicate<? super XMLNode> filter){
+    public Iterator<XMLNode> iterator(org.apache.commons.collections4.Predicate<? super XMLNode> filter){
         return new IndexIterator<>(this, filter);
     }
     @Override
@@ -75,9 +75,8 @@ public abstract class XMLNodeTree extends XMLNode implements
         }
     }
     public void addAll(Iterable<? extends XMLNode> iterable){
-        Iterator<? extends XMLNode> itr = iterable.iterator();
-        while (itr.hasNext()){
-            add(itr.next());
+        for (XMLNode xmlNode : iterable) {
+            add(xmlNode);
         }
     }
     public boolean add(XMLNode xmlNode) {
@@ -144,11 +143,11 @@ public abstract class XMLNodeTree extends XMLNode implements
      * Use removeIf
      * */
     @Deprecated
-    public boolean remove(Predicate<? super XMLNode> filter) {
+    public boolean remove(org.apache.commons.collections4.Predicate<? super XMLNode> filter) {
         throw new RuntimeException("Depreciated method");
     }
     @Override
-    public boolean removeIf(Predicate<? super XMLNode> filter) {
+    public boolean removeIf(org.apache.commons.collections4.Predicate<? super XMLNode> filter) {
         synchronized (this){
             return mNodeList.removeIf(filter);
         }

--- a/src/main/java/com/reandroid/xml/base/NodeTree.java
+++ b/src/main/java/com/reandroid/xml/base/NodeTree.java
@@ -20,7 +20,7 @@ import com.reandroid.utils.collection.InstanceIterator;
 
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.function.Predicate;
+
 
 public interface NodeTree<T extends Node> extends Node {
 
@@ -28,7 +28,7 @@ public interface NodeTree<T extends Node> extends Node {
     void add(int i, T node);
     boolean remove(T node);
     T remove(int i);
-    boolean removeIf(Predicate<? super T> predicate);
+    boolean removeIf(org.apache.commons.collections4.Predicate<? super T> predicate);
     T get(int i);
     int size();
     Iterator<? extends T> iterator();
@@ -44,7 +44,7 @@ public interface NodeTree<T extends Node> extends Node {
     default <T1 extends Node> Iterator<T1> iterator(Class<T1> instance) {
         return iterator(instance, null);
     }
-    default <T1 extends Node> Iterator<T1> iterator(Class<T1> instance, Predicate<? super T1> filter) {
+    default <T1 extends Node> Iterator<T1> iterator(Class<T1> instance, org.apache.commons.collections4.Predicate<? super T1> filter) {
         return new InstanceIterator<>(iterator(), instance, filter);
     }
 }

--- a/src/main/java/com/reandroid/xml/kxml2/KXmlParser.java
+++ b/src/main/java/com/reandroid/xml/kxml2/KXmlParser.java
@@ -22,6 +22,8 @@
 
 package com.reandroid.xml.kxml2;
 
+import com.reandroid.utils.StringsUtil;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -224,7 +226,7 @@ public class KXmlParser implements XmlPullParser, Closeable {
                 nspStack[j] = attrName;
                 nspStack[j + 1] = attributes[i + 3];
 
-                if (attrName != null && attributes[i + 3].isEmpty()) {
+                if (attrName != null && attributes[i + 3].length() == 0) {
                     checkRelaxed("illegal empty namespace");
                 }
 
@@ -452,7 +454,7 @@ public class KXmlParser implements XmlPullParser, Closeable {
              * reference.
              */
             int peek = peekType(false);
-            if (text != null && !text.isEmpty() && peek < TEXT) {
+            if (!StringsUtil.isEmpty(text) && peek < TEXT) {
                 type = TEXT;
                 return type;
             }

--- a/src/main/java/com/reandroid/xml/kxml2/KXmlSerializer.java
+++ b/src/main/java/com/reandroid/xml/kxml2/KXmlSerializer.java
@@ -20,6 +20,8 @@
 
 package com.reandroid.xml.kxml2;
 
+import com.reandroid.utils.StringsUtil;
+
 import java.io.*;
 import java.util.Arrays;
 import java.util.Locale;
@@ -121,11 +123,11 @@ public class KXmlSerializer implements XmlSerializer {
 
         for (int i = nspCounts[depth - 1]; i < nspCounts[depth]; i++){
             append(" xmlns");
-            if(!nspStack[i * 2].isEmpty()){
+            if(nspStack[i * 2].length() != 0){
                 append(':');
                 append(nspStack[i * 2]);
             }
-            else if(getNamespace().isEmpty() && !nspStack[i * 2 + 1].isEmpty())
+            else if(getNamespace().length() == 0 && nspStack[i * 2 + 1].length() != 0)
                 throw new IllegalStateException("Cannot set default namespace for elements in no namespace");
             append("=\"");
             writeEscaped(nspStack[i * 2 + 1], '"');
@@ -234,7 +236,7 @@ public class KXmlSerializer implements XmlSerializer {
         for (int i = nspCounts[depth + 1] * 2 - 2; i >= 0;i -= 2){
             if(nspStack[i + 1].equals(namespace)
                     && (includeDefault 
-                    || !nspStack[i].isEmpty())){
+                    || nspStack[i].length() != 0)){
                 String cand = nspStack[i];
                 for (int j = i + 2; j < nspCounts[depth + 1] * 2; j++){
                     if(nspStack[j].equals(cand)){
@@ -253,7 +255,7 @@ public class KXmlSerializer implements XmlSerializer {
 
         String prefix;
 
-        if(namespace.isEmpty()) {
+        if(namespace.length() == 0) {
             prefix = "";
         }else {
             do {
@@ -396,9 +398,9 @@ public class KXmlSerializer implements XmlSerializer {
         String prefix = namespace == null?
                 "" : getPrefix(namespace, true, true);
 
-        if(namespace != null && namespace.isEmpty()){
+        if(!StringsUtil.isEmpty(namespace)){
             for (int i = nspCounts[depth]; i < nspCounts[depth + 1]; i++){
-                if(nspStack[i * 2].isEmpty() && !nspStack[i * 2 + 1].isEmpty()){
+                if(nspStack[i * 2].length() == 0 && nspStack[i * 2 + 1].length() != 0){
                     throw new IllegalStateException("Cannot set default namespace for elements in no namespace");
                 }
             }
@@ -408,7 +410,7 @@ public class KXmlSerializer implements XmlSerializer {
         elementStack[esp] = name;
         append('<');
         indentAttributeReference += 1;
-        if(!prefix.isEmpty()){
+        if(prefix.length() != 0){
             append(prefix);
             append(':');
             indentAttributeReference += prefix.length() + 1;
@@ -431,11 +433,11 @@ public class KXmlSerializer implements XmlSerializer {
         if(namespace == null) {
             namespace = "";
         }
-        String prefix = namespace.isEmpty() ?
+        String prefix = namespace.length() == 0 ?
                 "" : getPrefix(namespace, false, true);
         attributeIndent();
         append(' ');
-        if(!prefix.isEmpty()){
+        if(prefix.length() != 0){
             append(prefix);
             append(':');
         }
@@ -478,7 +480,7 @@ public class KXmlSerializer implements XmlSerializer {
             }
             append("</");
             String prefix = elementStack[depth * 3 + 1];
-            if(!prefix.isEmpty()){
+            if(prefix.length() != 0){
                 append(prefix);
                 append(':');
             }

--- a/src/main/java/org/apache/commons/collections4/Closure.java
+++ b/src/main/java/org/apache/commons/collections4/Closure.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.collections4;
+
+/**
+ * Defines a functor interface implemented by classes that do something.
+ * <p>
+ * A {@code Closure} represents a block of code which is executed from
+ * inside some block, function or iteration. It operates an input object.
+ * </p>
+ * <p>
+ * Standard implementations of common closures are provided by
+ * {@link ClosureUtils}. These include method invocation and for/while loops.
+ * </p>
+ *
+ * @param <T> the type that the closure acts on
+ * @since 1.0
+ */
+@FunctionalInterface
+public interface Closure<T> {
+
+    /**
+     * Performs an action on the specified input object.
+     *
+     * @param input  the input to execute on
+     * @throws ClassCastException (runtime) if the input is the wrong class
+     * @throws IllegalArgumentException (runtime) if the input is invalid
+     * @throws FunctorException (runtime) if any other error occurs
+     */
+    void execute(T input);
+
+}

--- a/src/main/java/org/apache/commons/collections4/Predicate.java
+++ b/src/main/java/org/apache/commons/collections4/Predicate.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.collections4;
+
+/**
+ * Defines a functor interface implemented by classes that perform a predicate
+ * test on an object.
+ * <p>
+ * A {@code Predicate} is the object equivalent of an {@code if} statement.
+ * It uses the input object to return a true or false value, and is often used in
+ * validation or filtering.
+ * </p>
+ * <p>
+ * Standard implementations of common predicates are provided by
+ * {@link PredicateUtils}. These include true, false, instanceof, equals, and,
+ * or, not, method invocation and null testing.
+ * </p>
+ *
+ * @param <T> the type that the predicate queries
+ *
+ * @since 1.0
+ */
+@FunctionalInterface
+public interface Predicate<T> {
+
+    /**
+     * Use the specified parameter to perform a test that returns true or false.
+     *
+     * @param object  the object to evaluate, should not be changed
+     * @return true or false
+     * @throws ClassCastException (runtime) if the input is the wrong class
+     * @throws IllegalArgumentException (runtime) if the input is invalid
+     */
+    boolean evaluate(T object);
+
+}

--- a/src/main/java/org/apache/commons/collections4/Transformer.java
+++ b/src/main/java/org/apache/commons/collections4/Transformer.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.collections4;
+
+/**
+ * Defines a functor interface implemented by classes that transform one
+ * object into another.
+ * <p>
+ * A {@code Transformer} converts the input object to the output object.
+ * The input object should be left unchanged.
+ * Transformers are typically used for type conversions, or extracting data
+ * from an object.
+ * </p>
+ * <p>
+ * Standard implementations of common transformers are provided by
+ * {@link TransformerUtils}. These include method invocation, returning a constant,
+ * cloning and returning the string value.
+ * </p>
+ *
+ * @param <I> the input type to the transformer
+ * @param <O> the output type from the transformer
+ *
+ * @since 1.0
+ */
+@FunctionalInterface
+public interface Transformer<I, O> {
+
+    /**
+     * Transforms the input object (leaving it unchanged) into some output object.
+     *
+     * @param input  the object to be transformed, should be left unchanged
+     * @return a transformed object
+     * @throws ClassCastException (runtime) if the input is the wrong class
+     * @throws IllegalArgumentException (runtime) if the input is invalid
+     * @throws FunctorException (runtime) if the transform cannot be completed
+     */
+    O transformer(I input);
+
+}


### PR DESCRIPTION
Similar to https://github.com/REAndroid/APKEditor/pull/156, with some minor changes, support for all Android versions can be established for use of ARSCLib and/or APKEditor in an Android application with no further modification of the tools necessary.