### PR TITLE
Ensure data is fully transferred between channels

### DIFF
--- a/src/main/java/com/reandroid/archive/ArchiveFile.java
+++ b/src/main/java/com/reandroid/archive/ArchiveFile.java
@@ -41,7 +41,16 @@ public class ArchiveFile extends Archive<ZipFileInput>{
         FileChannel outputChannel = FileUtil.openWriteChannel(file);
         FileChannel fileChannel = getZipInput().getFileChannel();
         fileChannel.position(archiveEntry.getFileOffset());
-        outputChannel.transferFrom(fileChannel, 0, archiveEntry.getDataSize());
+
+        long totalTransferred = 0;
+        long remaining = archiveEntry.getDataSize();
+
+        while (remaining > 0) {
+            long transferred = outputChannel.transferFrom(fileChannel, totalTransferred, remaining);
+            totalTransferred += transferred;
+            remaining -= transferred;
+        }
+
         outputChannel.close();
     }
 }

--- a/src/main/java/com/reandroid/archive/io/ArchiveFileEntrySource.java
+++ b/src/main/java/com/reandroid/archive/io/ArchiveFileEntrySource.java
@@ -58,7 +58,16 @@ public class ArchiveFileEntrySource extends ArchiveEntrySource<ZipFileInput> {
             return;
         }
         FileChannel outputChannel = FileUtil.openWriteChannel(file);
-        outputChannel.transferFrom(fileChannel, 0, getLength());
+
+        long totalTransferred = 0;
+        long remaining = getLength();
+
+        while (remaining > 0) {
+            long transferred = outputChannel.transferFrom(fileChannel, totalTransferred, remaining);
+            totalTransferred += transferred;
+            remaining -= transferred;
+        }
+
         outputChannel.close();
     }
 

--- a/src/main/java/com/reandroid/archive/io/ZipFileOutput.java
+++ b/src/main/java/com/reandroid/archive/io/ZipFileOutput.java
@@ -37,8 +37,17 @@ public class ZipFileOutput extends ZipOutput{
     public void write(FileChannel input, long length) throws IOException{
         FileChannel fileChannel = getFileChannel();
         long pos = fileChannel.position();
-        length = fileChannel.transferFrom(input, pos, length);
-        fileChannel.position(pos + length);
+
+        long totalTransferred = 0;
+        long remaining = length;
+
+        while (remaining > 0) {
+            long transferred = fileChannel.transferFrom(input, pos + totalTransferred, remaining);
+            totalTransferred += transferred;
+            remaining -= transferred;
+        }
+
+        fileChannel.position(pos + totalTransferred);
     }
 
     @Override


### PR DESCRIPTION
`FileChannel::transferFrom` is not guaranteed to transfer all data requested in one call. This could lead to scenarios where data gets written only partially, leading to corrupted outputs.

I have observed this when using ARSC in APKEditor, but not when writing a test for ARSC specifically. This is unfortunately beyond the test control and I cannot provide a test for this fix.

In particular, writing a merged APK before the fix would get logged as successful, but using `unzip -t output.apk` would result in:
```
 extracting: lib/arm64-v8a/libsomenativelibrary.so   bad CRC 65c63f68  (should be 92b9a41a)
error: invalid zip file with overlapped components (possible zip bomb)
 To unzip the file anyway, rerun the command with UNZIP_DISABLE_ZIPBOMB_DETECTION=TRUE environmnent variable
 ```

I have verified it decompresses correctly with this fix

While the issue has only been observed in ZipFileOutput, I have
pre-emptively implemented the fix to all uses of `transferFrom`.