### PR TITLE
optimize decodeValueTypes

### DIFF
--- a/src/main/java/com/reandroid/arsc/value/AttributeDataFormat.java
+++ b/src/main/java/com/reandroid/arsc/value/AttributeDataFormat.java
@@ -159,11 +159,11 @@ public enum AttributeDataFormat {
     }
 
     public static AttributeDataFormat[] decodeValueTypes(int data){
-        data &= 0xffff;
+        data &= 0xff;
         if(data == 0){
             return null;
         }
-        if(data == 0xffff){
+        if(data == 0xff){
             return new AttributeDataFormat[]{AttributeDataFormat.ANY};
         }
         final int length = Integer.bitCount(data);

--- a/src/main/java/com/reandroid/arsc/value/AttributeDataFormat.java
+++ b/src/main/java/com/reandroid/arsc/value/AttributeDataFormat.java
@@ -159,26 +159,11 @@ public enum AttributeDataFormat {
     }
 
     public static AttributeDataFormat[] decodeValueTypes(int data){
-        AttributeDataFormat[] tmp = new AttributeDataFormat[VALUE_TYPES.length];
-        int length = 0;
-        for(AttributeDataFormat typeValue : VALUE_TYPES){
-            int mask = typeValue.getMask();
-            if(mask == data){
-                return new AttributeDataFormat[]{typeValue};
-            }
-            if(typeValue == ANY){
-                continue;
-            }
-            if((data & mask) == mask){
-                tmp[length] = typeValue;
-                length++;
-            }
-        }
-        if(length == 0){
-            return null;
-        }
-        AttributeDataFormat[] results = new AttributeDataFormat[length];
-        System.arraycopy(tmp, 0, results, 0, length);
+        final int length = Integer.bitCount(data & 0xffff);
+        if(length == 0)return null;
+        final AttributeDataFormat[] results = new AttributeDataFormat[length];
+        for(int i = 0, j = 0; i < VALUE_TYPES.length - 1 && j < results.length; ++i)
+            if(((data >> i) & 1) != 0) results[j++] = VALUE_TYPES[i];
         return results;
     }
     public static AttributeDataFormat[] parseValueTypes(String valuesTypes){

--- a/src/main/java/com/reandroid/arsc/value/AttributeDataFormat.java
+++ b/src/main/java/com/reandroid/arsc/value/AttributeDataFormat.java
@@ -160,12 +160,19 @@ public enum AttributeDataFormat {
 
     public static AttributeDataFormat[] decodeValueTypes(int data){
         data &= 0xffff;
-        if(data == 0) return null;
-        if(data == 0xffff) return new AttributeDataFormat[]{AttributeDataFormat.ANY};
+        if(data == 0){
+            return null;
+        }
+        if(data == 0xffff){
+            return new AttributeDataFormat[]{AttributeDataFormat.ANY};
+        }
         final int length = Integer.bitCount(data);
         final AttributeDataFormat[] results = new AttributeDataFormat[length];
-        for(int i = 0, j = 0; i < VALUE_TYPES.length - 1 && j < results.length; ++i)
-            if(((data >> i) & 1) != 0) results[j++] = VALUE_TYPES[i];
+        for(int i = 0, j = 0; i < VALUE_TYPES.length - 1 && j < results.length; ++i){
+            if(((data >> i) & 1) != 0){
+                results[j++] = VALUE_TYPES[i];
+            }
+        }
         return results;
     }
     public static AttributeDataFormat[] parseValueTypes(String valuesTypes){

--- a/src/main/java/com/reandroid/arsc/value/AttributeDataFormat.java
+++ b/src/main/java/com/reandroid/arsc/value/AttributeDataFormat.java
@@ -158,20 +158,24 @@ public enum AttributeDataFormat {
         return result;
     }
 
-    public static AttributeDataFormat[] decodeValueTypes(int data){
+    public static AttributeDataFormat[] decodeValueTypes(int data) {
+        if ((data & 0xffff) == 0xffff) {
+            return new AttributeDataFormat[]{ANY};
+        }
         data &= 0xff;
-        if(data == 0){
+        if (data == 0) {
             return null;
         }
-        if(data == 0xff){
-            return new AttributeDataFormat[]{AttributeDataFormat.ANY};
-        }
-        final int length = Integer.bitCount(data);
-        final AttributeDataFormat[] results = new AttributeDataFormat[length];
-        for(int i = 0, j = 0; i < VALUE_TYPES.length - 1 && j < results.length; ++i){
-            if(((data >> i) & 1) != 0){
-                results[j++] = VALUE_TYPES[i];
+        AttributeDataFormat[] results = new AttributeDataFormat[Integer.bitCount(data)];
+        AttributeDataFormat[] valueTypes = VALUE_TYPES;
+        int length = valueTypes.length - 1;
+        int j = 0;
+        for (int i = 0; i < length; i++) {
+            if ((data & 1) != 0) {
+                results[j] = valueTypes[i];
+                j ++;
             }
+            data = data >> 1;
         }
         return results;
     }

--- a/src/main/java/com/reandroid/arsc/value/AttributeDataFormat.java
+++ b/src/main/java/com/reandroid/arsc/value/AttributeDataFormat.java
@@ -159,8 +159,10 @@ public enum AttributeDataFormat {
     }
 
     public static AttributeDataFormat[] decodeValueTypes(int data){
-        final int length = Integer.bitCount(data & 0xffff);
-        if(length == 0)return null;
+        data &= 0xffff;
+        if(data == 0) return null;
+        if(data == 0xffff) return new AttributeDataFormat[]{AttributeDataFormat.ANY};
+        final int length = Integer.bitCount(data);
         final AttributeDataFormat[] results = new AttributeDataFormat[length];
         for(int i = 0, j = 0; i < VALUE_TYPES.length - 1 && j < results.length; ++i)
             if(((data >> i) & 1) != 0) results[j++] = VALUE_TYPES[i];


### PR DESCRIPTION
The idea is using "population count" to pre-compute final array size and eliminate usage of temporary array.